### PR TITLE
feat: confirm password

### DIFF
--- a/src/modules/auth/components/SignUpForm.tsx
+++ b/src/modules/auth/components/SignUpForm.tsx
@@ -68,7 +68,7 @@ export function SignUpForm() {
         <PasswordInput<SignUpSchemaType>
           className={"col-span-12 lg:col-span-6"}
           control={control}
-          label={"Password Confirmation"}
+          label={"Password confirmation"}
           name={"confirmPassword"}
           placeholder={"Retype your password"}
           rules={{ required: true }}

--- a/src/modules/auth/components/SignUpForm.tsx
+++ b/src/modules/auth/components/SignUpForm.tsx
@@ -46,6 +46,16 @@ export function SignUpForm() {
           type={"text"}
         />
 
+        <InputField<SignUpSchemaType>
+          className={"col-span-12 lg:col-span-6"}
+          control={control}
+          label={"E-mail"}
+          name={"email"}
+          placeholder={"Type your e-mail"}
+          rules={{ required: true }}
+          type={"email"}
+        />
+
         <PasswordInput<SignUpSchemaType>
           className={"col-span-12 lg:col-span-6"}
           control={control}
@@ -55,14 +65,13 @@ export function SignUpForm() {
           rules={{ required: true }}
         />
 
-        <InputField<SignUpSchemaType>
+        <PasswordInput<SignUpSchemaType>
           className={"col-span-12 lg:col-span-6"}
           control={control}
-          label={"E-mail"}
-          name={"email"}
-          placeholder={"Type your e-mail"}
+          label={"Password Confirmation"}
+          name={"confirmPassword"}
+          placeholder={"Retype your password"}
           rules={{ required: true }}
-          type={"email"}
         />
 
         <InputField<SignUpSchemaType>
@@ -76,7 +85,7 @@ export function SignUpForm() {
         />
 
         <InputField<SignUpSchemaType>
-          className={"col-span-12"}
+          className={"col-span-12 lg:col-span-6"}
           control={control}
           label={"Phone number"}
           name={"phoneNumber"}

--- a/src/modules/auth/schemas/sign-up.schema.ts
+++ b/src/modules/auth/schemas/sign-up.schema.ts
@@ -1,48 +1,56 @@
 import { z } from "zod";
 
 export const SignUpSchema = z.object({
-  email: z
-    .string({
-      required_error: "",
-    })
-    .regex(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/, {
-      message: "E-mail format is not valid",
-    }),
-  fullName: z
-    .string({
-      required_error: "",
-    })
-    .min(3, {
-      message: "Full name must be at least 3 characters long",
-    })
-    .max(20, {
-      message: "Full name must be at most 20 characters long",
-    }),
-  password: z
-    .string({
-      required_error: "",
-    })
-    .min(6, {
-      message: "Password must be at least 6 characters long",
-    })
-    .max(20, {
-      message: "Password must be at most 20 characters long",
-    }),
-  phoneNumber: z
-    .string({
-      required_error: "",
-    })
-    .regex(/^\d{10}$/, { message: "Phone number is not valid" }),
-  username: z
-    .string({
-      required_error: "",
-    })
-    .min(3, {
-      message: "Username must be at least 3 characters long",
-    })
-    .max(20, {
-      message: "Username must be at most 20 characters long",
-    }),
-});
+    email: z
+      .string({
+        required_error: "",
+      })
+      .regex(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/, {
+        message: "E-mail format is not valid",
+      }),
+    fullName: z
+      .string({
+        required_error: "",
+      })
+      .min(3, {
+        message: "Full name must be at least 3 characters long",
+      })
+      .max(20, {
+        message: "Full name must be at most 20 characters long",
+      }),
+    password: z
+      .string({
+        required_error: "",
+      })
+      .min(6, {
+        message: "Password must be at least 6 characters long",
+      })
+      .max(20, {
+        message: "Password must be at most 20 characters long",
+      }),
+    confirmPassword: z
+      .string({
+        required_error: "",
+      }),
+    phoneNumber: z
+      .string({
+        required_error: "",
+      })
+      .regex(/^\d{10}$/, { message: "Phone number is not valid" }),
+    username: z
+      .string({
+        required_error: "",
+      })
+      .min(3, {
+        message: "Username must be at least 3 characters long",
+      })
+      .max(20, {
+        message: "Username must be at most 20 characters long",
+      }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords must match",
+    path: ["confirmPassword"],
+  });
 
 export type SignUpSchemaType = z.infer<typeof SignUpSchema>;


### PR DESCRIPTION
Se agregó una funcionalidad en el front para reconfirmar la contraseña del usuario añadiendo seguridad al registro en caso de que el usuario no haya ingresado su contraseña correctamente en el primer intento.

![image](https://github.com/user-attachments/assets/de2a0099-346b-47d7-95ae-5df7c12108e1)

Se agregó un nuevo atributo en el objeto de Zod denominado 'confirmPassword' que valida que el contenido de su campo sea igual al del 'password' original. En caso de no serlo, se muestra un mensaje de alerta y se impide el registro.