### PR TITLE
feat: register users

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import { httpClient } from "@/shared/lib/httpClient.ts";
 import { ActivateUserRequest } from "@auth/interfaces/requests/activate-user.interface.ts";
+import { SignUpRequest } from "@auth/interfaces/requests/sign-up.interface.ts";
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 
@@ -13,3 +14,7 @@ export const activateUser = async (params: ActivateUserRequest) => {
     },
   );
 };
+
+export async function signUpUser(params: SignUpRequest) {
+  await httpClient.post(`${BACKEND_URL}/auth/signup`, params);
+}

--- a/src/modules/auth/components/SignUpForm.tsx
+++ b/src/modules/auth/components/SignUpForm.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@nextui-org/react";
-import { SubmitHandler, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import { InputField } from "@/shared/components/ui/InputField.tsx";
@@ -9,12 +9,17 @@ import {
   SignUpSchemaType,
 } from "@/modules/auth/schemas/sign-up.schema.ts";
 import { Title } from "@/shared/components/typography/Title.tsx";
+import { useSignUp } from "@auth/hooks/useSignUp.ts";
 
 export function SignUpForm() {
+  const { mutate, isPending } = useSignUp();
   const { control, handleSubmit } = useForm<SignUpSchemaType>({
     resolver: zodResolver(SignUpSchema),
   });
-  const onSubmit: SubmitHandler<SignUpSchemaType> = (data) => console.log(data);
+
+  function onSubmit(data: SignUpSchemaType) {
+    mutate(data);
+  }
 
   return (
     <form
@@ -35,12 +40,7 @@ export function SignUpForm() {
           label={"Username"}
           name={"username"}
           placeholder={"Type your username"}
-          rules={{
-            minLength: {
-              value: 3,
-              message: "The username must have at least 3 characters",
-            },
-          }}
+          rules={{ required: true }}
           type={"text"}
         />
 
@@ -93,7 +93,7 @@ export function SignUpForm() {
         />
       </div>
 
-      <Button color={"secondary"} type={"submit"}>
+      <Button isLoading={isPending} color={"secondary"} type={"submit"}>
         Create account
       </Button>
     </form>

--- a/src/modules/auth/constants.ts
+++ b/src/modules/auth/constants.ts
@@ -1,1 +1,1 @@
-export const AUTH_SIGN_IN_KEY = "auth/sign-in";
+export const AUTH_SIGN_UP_KEY = "auth/sign-in";

--- a/src/modules/auth/constants.ts
+++ b/src/modules/auth/constants.ts
@@ -1,0 +1,1 @@
+export const AUTH_SIGN_IN_KEY = "auth/sign-in";

--- a/src/modules/auth/constants.ts
+++ b/src/modules/auth/constants.ts
@@ -1,1 +1,1 @@
-export const AUTH_SIGN_UP_KEY = "auth/sign-in";
+export const AUTH_SIGN_UP_KEY = "auth/sign-up";

--- a/src/modules/auth/hooks/useSignUp.ts
+++ b/src/modules/auth/hooks/useSignUp.ts
@@ -7,7 +7,7 @@ import { signUpUser } from "@auth/auth.service.ts";
 export function useSignUp() {
   const navigate = useNavigate();
   const { isError, isPending, mutate } = useMutation({
-    mutationKey: [AUTH_SIGN_IN_KEY],
+    mutationKey: [AUTH_SIGN_UP_KEY],
     mutationFn: signUpUser,
     onSuccess: () => {
       navigate("/auth/email-sent", { replace: true });

--- a/src/modules/auth/hooks/useSignUp.ts
+++ b/src/modules/auth/hooks/useSignUp.ts
@@ -1,7 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
-import { AUTH_SIGN_IN_KEY } from "@auth/constants.ts";
+import { AUTH_SIGN_UP_KEY } from "@auth/constants.ts";
 import { signUpUser } from "@auth/auth.service.ts";
 
 export function useSignUp() {

--- a/src/modules/auth/hooks/useSignUp.ts
+++ b/src/modules/auth/hooks/useSignUp.ts
@@ -1,0 +1,22 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+import { AUTH_SIGN_IN_KEY } from "@auth/constants.ts";
+import { signUpUser } from "@auth/auth.service.ts";
+
+export function useSignUp() {
+  const navigate = useNavigate();
+  const { isError, isPending, mutate } = useMutation({
+    mutationKey: [AUTH_SIGN_IN_KEY],
+    mutationFn: signUpUser,
+    onSuccess: () => {
+      navigate("/auth/email-sent", { replace: true });
+    },
+  });
+
+  return {
+    isError,
+    isPending,
+    mutate,
+  };
+}

--- a/src/modules/auth/interfaces/requests/sign-up.interface.ts
+++ b/src/modules/auth/interfaces/requests/sign-up.interface.ts
@@ -1,0 +1,7 @@
+export interface SignUpRequest {
+  email: string;
+  fullName: string;
+  password: string;
+  phoneNumber: string;
+  username: string;
+}

--- a/src/providers/RoutesProvider.tsx
+++ b/src/providers/RoutesProvider.tsx
@@ -8,6 +8,7 @@ import { HomePage } from "@/shared/pages/HomePage.tsx";
 import { ProductsPage } from "@/shared/pages/ProductsPage.tsx";
 import { SignInPage } from "@/shared/pages/auth/SignInPage.tsx";
 import { SignUpPage } from "@/shared/pages/auth/SignUpPage.tsx";
+import { EmailSent } from "@/shared/pages/auth/EmailSent.tsx";
 
 export default function RoutesProvider() {
   const navigate = useNavigate();
@@ -22,6 +23,7 @@ export default function RoutesProvider() {
           <Route path={"signup"} element={<SignUpPage />} />
           <Route path={"signin"} element={<SignInPage />} />
           <Route path={"activate"} element={<ActivateUserPage />} />
+          <Route path={"email-sent"} element={<EmailSent />} />
         </Route>
       </Routes>
     </NextUIProvider>

--- a/src/shared/pages/auth/EmailSent.tsx
+++ b/src/shared/pages/auth/EmailSent.tsx
@@ -1,0 +1,17 @@
+import { Title } from "@/shared/components/typography/Title.tsx";
+
+export function EmailSent() {
+  return (
+    <div className={"fadeInUp flex flex-col items-center gap-6 text-center"}>
+      <header>
+        <Title>Account created</Title>
+      </header>
+
+      <div className={"flex flex-col gap-1"}>
+        <p>Please check your email to confirm your account.</p>
+        <p>If you didn't receive the email, please check your spam folder.</p>
+        <p>We hope to see you again!</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Explicación
Se realizó la implementación del registro de usuarios. Anteriormente solo teníamos definido el formulario con sus validaciones, pero no definimos que hacia una vez que el ocurría el submit.

Para ello, cree una función que se encarga de realizar la solicitud HTTP al backend. Luego, utilicé esta función en una **mutación** de React Query, la cual me provee valores para saber si ocurrió un error o si se esta realizando la petición (útil para mostrar el estado de carga en el botón)

Finalmente, cree una pagina para indicarle al usuario que se le ha enviado un e-mail para no tener que redirigirlo al inicio de sesión, lo cual seria inútil ya que no podría acceder.
# Visualización
![ezgif-4-1b92b72955](https://github.com/user-attachments/assets/2655fb0e-b98f-44b2-b75b-6be4b8afccf1)
