### PR TITLE
feat: administration panel

### DIFF
--- a/src/providers/RoutesProvider.tsx
+++ b/src/providers/RoutesProvider.tsx
@@ -2,14 +2,19 @@ import { Route, Routes, useNavigate } from "react-router-dom";
 import { NextUIProvider } from "@nextui-org/react";
 
 import { ActivateUserPage } from "@/shared/pages/auth/ActivateUserPage.tsx";
+import { AdminLayout } from "@/shared/pages/layouts/AdminLayout.tsx";
+import { AdminPage } from "@/shared/pages/admin/AdminPage.tsx";
 import { AppLayout } from "@/shared/pages/layouts/AppLayout.tsx";
 import { AuthLayout } from "@/shared/pages/layouts/AuthLayout.tsx";
+import { EmailSent } from "@/shared/pages/auth/EmailSent.tsx";
 import { HomePage } from "@/shared/pages/HomePage.tsx";
 import { ProductsPage } from "@/shared/pages/ProductsPage.tsx";
+import { ProtectedRoute } from "@/shared/pages/routes/ProtectedRoute.tsx";
+import { Role } from "@/modules/users/enums/role.enum.ts";
 import { SignInPage } from "@/shared/pages/auth/SignInPage.tsx";
 import { SignUpPage } from "@/shared/pages/auth/SignUpPage.tsx";
-import { EmailSent } from "@/shared/pages/auth/EmailSent.tsx";
 import { UnauthenticatedRoute } from "@/shared/pages/routes/UnauthenticatedRoute.tsx";
+import { CategoryAdminPage } from "@/shared/pages/admin/CategoryAdminPage.tsx";
 
 export default function RoutesProvider() {
   const navigate = useNavigate();
@@ -19,24 +24,28 @@ export default function RoutesProvider() {
         <Route path={"/"} element={<AppLayout />}>
           <Route index element={<HomePage />} />
           <Route path={"products"} element={<ProductsPage />} />
+          <Route
+            path={"admin"}
+            element={
+              <ProtectedRoute allowedRoles={[Role.ADMIN]}>
+                <AdminLayout />
+              </ProtectedRoute>
+            }
+          >
+            <Route index element={<AdminPage />} />
+            <Route path={"categories"} element={<CategoryAdminPage />} />
+          </Route>
         </Route>
-        <Route path={"/auth"} element={<AuthLayout />}>
-          <Route
-            path={"signup"}
-            element={
-              <UnauthenticatedRoute>
-                <SignUpPage />
-              </UnauthenticatedRoute>
-            }
-          />
-          <Route
-            path={"signin"}
-            element={
-              <UnauthenticatedRoute>
-                <SignInPage />
-              </UnauthenticatedRoute>
-            }
-          />
+        <Route
+          path={"/auth"}
+          element={
+            <UnauthenticatedRoute>
+              <AuthLayout />
+            </UnauthenticatedRoute>
+          }
+        >
+          <Route path={"signup"} element={<SignUpPage />} />
+          <Route path={"signin"} element={<SignInPage />} />
           <Route path={"activate"} element={<ActivateUserPage />} />
           <Route path={"email-sent"} element={<EmailSent />} />
         </Route>

--- a/src/shared/components/icons/CategoryIcon.tsx
+++ b/src/shared/components/icons/CategoryIcon.tsx
@@ -1,0 +1,36 @@
+export function CategoryIcon() {
+  return (
+    <svg
+      className={"size-5 lg:size-7"}
+      fill="none"
+      stroke="#808080"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path
+        d="M10 3h-6a1 1 0 0 0 -1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1 -1v-6a1 1 0 0 0 -1 -1z"
+        stroke-width="0"
+        fill="#53535B"
+      />
+      <path
+        d="M20 3h-6a1 1 0 0 0 -1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1 -1v-6a1 1 0 0 0 -1 -1z"
+        stroke-width="0"
+        fill="#53535B"
+      />
+      <path
+        d="M10 13h-6a1 1 0 0 0 -1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1 -1v-6a1 1 0 0 0 -1 -1z"
+        stroke-width="0"
+        fill="#53535B"
+      />
+      <path
+        d="M17 13a4 4 0 1 1 -3.995 4.2l-.005 -.2l.005 -.2a4 4 0 0 1 3.995 -3.8z"
+        stroke-width="0"
+        fill="#53535B"
+      />
+    </svg>
+  );
+}

--- a/src/shared/components/icons/HomeIcon.tsx
+++ b/src/shared/components/icons/HomeIcon.tsx
@@ -1,0 +1,19 @@
+export function HomeIcon() {
+  return (
+    <svg
+      className={"size-5 lg:size-7"}
+      fill="#53535B"
+      stroke="#53535B"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M5 12l-2 0l9 -9l9 9l-2 0" />
+      <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7" />
+      <path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6" />
+    </svg>
+  );
+}

--- a/src/shared/components/icons/LayoutIcon.tsx
+++ b/src/shared/components/icons/LayoutIcon.tsx
@@ -1,0 +1,21 @@
+export function LayoutIcon() {
+  return (
+    <svg
+      fill="none"
+      height="36"
+      stroke="#52525B"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      viewBox="0 0 24 24"
+      width="36"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M4 4h6v8h-6z" />
+      <path d="M4 16h6v4h-6z" />
+      <path d="M14 12h6v8h-6z" />
+      <path d="M14 4h6v4h-6z" />
+    </svg>
+  );
+}

--- a/src/shared/components/ui/Navbar.tsx
+++ b/src/shared/components/ui/Navbar.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Divider,
   Link,
   Navbar as NextNavbar,
   NavbarBrand,
@@ -13,6 +14,9 @@ import { useLocation } from "react-router-dom";
 import { Title } from "@/shared/components/typography/Title.tsx";
 import { useAuthStore } from "@auth/hooks/useAuthStore.ts";
 import RenderIf from "@/shared/components/RenderIf.tsx";
+import { LayoutIcon } from "@/shared/components/icons/LayoutIcon.tsx";
+import { RoleBasedVisibility } from "@/shared/components/ui/RoleBasedVisibility.tsx";
+import { Role } from "@/modules/users/enums/role.enum.ts";
 
 export function Navbar() {
   const { isAuthenticated, logout } = useAuthStore();
@@ -33,15 +37,17 @@ export function Navbar() {
       disableAnimation
       isBlurred
       maxWidth={"full"}
-      className={"bg-background py-3"}
+      className={
+        "border-1 border-r-0 border-t-0 border-b-default/50 bg-background py-3"
+      }
     >
-      <NavbarContent className="pr-3 sm:hidden" justify="center">
+      <NavbarContent className="pr-3 lg:hidden" justify="center">
         <NavbarBrand>
           <Title className={"text-3xl"}>Megastore</Title>
         </NavbarBrand>
       </NavbarContent>
 
-      <NavbarContent className="hidden gap-4 sm:flex" justify="center">
+      <NavbarContent className="hidden gap-4 lg:flex" justify="center">
         <NavbarBrand className={"pr-4"}>
           <Title>Megastore</Title>
         </NavbarBrand>
@@ -56,33 +62,20 @@ export function Navbar() {
         })}
       </NavbarContent>
 
-      <NavbarContent className="sm:hidden" justify="end">
-        <div className={"pr-2"}>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="32"
-            height="32"
-            fill="#000000"
-            viewBox="0 0 256 256"
-          >
-            <path d="M230.14,58.87A8,8,0,0,0,224,56H62.68L56.6,22.57A8,8,0,0,0,48.73,16H24a8,8,0,0,0,0,16h18L67.56,172.29a24,24,0,0,0,5.33,11.27,28,28,0,1,0,44.4,8.44h45.42A27.75,27.75,0,0,0,160,204a28,28,0,1,0,28-28H91.17a8,8,0,0,1-7.87-6.57L80.13,152h116a24,24,0,0,0,23.61-19.71l12.16-66.86A8,8,0,0,0,230.14,58.87ZM104,204a12,12,0,1,1-12-12A12,12,0,0,1,104,204Zm96,0a12,12,0,1,1-12-12A12,12,0,0,1,200,204Zm4-74.57A8,8,0,0,1,196.1,136H77.22L65.59,72H214.41Z"></path>
-          </svg>
-        </div>
+      {/* Content for mobile */}
+      <NavbarContent className="lg:hidden" justify="end">
+        <div className={"pr-2"}></div>
         <NavbarMenuToggle />
       </NavbarContent>
 
+      {/* Content for desktop */}
       <NavbarContent justify="end" className={"hidden lg:flex"}>
-        <div>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="32"
-            height="32"
-            fill="#000000"
-            viewBox="0 0 256 256"
-          >
-            <path d="M230.14,58.87A8,8,0,0,0,224,56H62.68L56.6,22.57A8,8,0,0,0,48.73,16H24a8,8,0,0,0,0,16h18L67.56,172.29a24,24,0,0,0,5.33,11.27,28,28,0,1,0,44.4,8.44h45.42A27.75,27.75,0,0,0,160,204a28,28,0,1,0,28-28H91.17a8,8,0,0,1-7.87-6.57L80.13,152h116a24,24,0,0,0,23.61-19.71l12.16-66.86A8,8,0,0,0,230.14,58.87ZM104,204a12,12,0,1,1-12-12A12,12,0,0,1,104,204Zm96,0a12,12,0,1,1-12-12A12,12,0,0,1,200,204Zm4-74.57A8,8,0,0,1,196.1,136H77.22L65.59,72H214.41Z"></path>
-          </svg>
-        </div>
+        <RoleBasedVisibility allowedRoles={[Role.ADMIN]}>
+          <Link href={"/admin"}>
+            <LayoutIcon />
+          </Link>
+          <Divider orientation={"vertical"} />
+        </RoleBasedVisibility>
 
         <RenderIf condition={!isAuthenticated}>
           <NavbarItem>
@@ -122,6 +115,29 @@ export function Navbar() {
               </NavbarMenuItem>
             );
           })}
+        </div>
+
+        <div className={"flex flex-col gap-2"}>
+          <RoleBasedVisibility allowedRoles={[Role.ADMIN]}>
+            <NavbarMenuItem isActive={pathname === "/admin"}>
+              <Link href={"/admin"} color={"foreground"}>
+                Admin panel
+              </Link>
+            </NavbarMenuItem>
+          </RoleBasedVisibility>
+
+          <RenderIf condition={isAuthenticated}>
+            <NavbarMenuItem>
+              <Button
+                onClick={logout}
+                color="secondary"
+                variant="flat"
+                className={"w-full"}
+              >
+                Logout
+              </Button>
+            </NavbarMenuItem>
+          </RenderIf>
         </div>
 
         <RenderIf condition={!isAuthenticated}>

--- a/src/shared/pages/admin/AdminPage.tsx
+++ b/src/shared/pages/admin/AdminPage.tsx
@@ -1,3 +1,9 @@
+import { Title } from "@/shared/components/typography/Title.tsx";
+
 export function AdminPage() {
-  return <div className={"p-6"}>AdminPage</div>;
+  return (
+    <div className={"p-6"}>
+      <Title>Dashboard</Title>
+    </div>
+  );
 }

--- a/src/shared/pages/admin/AdminPage.tsx
+++ b/src/shared/pages/admin/AdminPage.tsx
@@ -1,0 +1,3 @@
+export function AdminPage() {
+  return <div className={"p-6"}>AdminPage</div>;
+}

--- a/src/shared/pages/admin/CategoryAdminPage.tsx
+++ b/src/shared/pages/admin/CategoryAdminPage.tsx
@@ -1,0 +1,11 @@
+import { Title } from "@/shared/components/typography/Title.tsx";
+
+export function CategoryAdminPage() {
+  return (
+    <div className={"p-6"}>
+      <header className={"items- center flex w-full justify-between gap-2"}>
+        <Title>List of categories</Title>
+      </header>
+    </div>
+  );
+}

--- a/src/shared/pages/layouts/AdminLayout.tsx
+++ b/src/shared/pages/layouts/AdminLayout.tsx
@@ -1,0 +1,45 @@
+import { Outlet, useLocation } from "react-router-dom";
+import { Link } from "@nextui-org/react";
+import { CategoryIcon } from "@/shared/components/icons/CategoryIcon.tsx";
+
+export function AdminLayout() {
+  const { pathname } = useLocation();
+  const adminItems = [
+    {
+      path: "/admin/categories",
+      label: "Categories",
+    },
+  ];
+
+  return (
+    <section className={"min-h-screenMinusNavbar w-full"}>
+      <aside
+        className={
+          "w-admin-sidebar fixed flex h-full flex-col gap-2 border-1 border-b-0 border-t-0 border-r-default/50 bg-background p-2 md:p-6"
+        }
+      >
+        {adminItems.map((item) => {
+          const { label, path } = item;
+          const isActive = pathname === path;
+
+          return (
+            <Link
+              className={`flex items-center justify-center gap-4 rounded-md p-2 text-lg text-foreground transition-all duration-75 ease-linear md:p-3 ${isActive ? "bg-primary/10 font-medium" : ""}`}
+              href={path}
+              key={path}
+            >
+              <span className={"hidden md:block"}>{label}</span>
+              <div className={"md:hidden"}>
+                <CategoryIcon />
+              </div>
+            </Link>
+          );
+        })}
+      </aside>
+
+      <div className={"pl-admin-sidebar"}>
+        <Outlet />
+      </div>
+    </section>
+  );
+}

--- a/src/shared/pages/layouts/AdminLayout.tsx
+++ b/src/shared/pages/layouts/AdminLayout.tsx
@@ -15,7 +15,7 @@ export function AdminLayout() {
     <section className={"min-h-screenMinusNavbar w-full"}>
       <aside
         className={
-          "w-admin-sidebar fixed flex h-full flex-col gap-2 border-1 border-b-0 border-t-0 border-r-default/50 bg-background p-2 md:p-6"
+          "w-adminSidebar fixed flex h-full flex-col gap-2 border-1 border-b-0 border-t-0 border-r-default/50 bg-background p-2 md:p-6"
         }
       >
         {adminItems.map((item) => {
@@ -37,7 +37,7 @@ export function AdminLayout() {
         })}
       </aside>
 
-      <div className={"pl-admin-sidebar"}>
+      <div className={"pl-adminSidebar"}>
         <Outlet />
       </div>
     </section>

--- a/src/shared/pages/layouts/AdminLayout.tsx
+++ b/src/shared/pages/layouts/AdminLayout.tsx
@@ -1,13 +1,20 @@
 import { Outlet, useLocation } from "react-router-dom";
 import { Link } from "@nextui-org/react";
 import { CategoryIcon } from "@/shared/components/icons/CategoryIcon.tsx";
+import { HomeIcon } from "@/shared/components/icons/HomeIcon.tsx";
 
 export function AdminLayout() {
   const { pathname } = useLocation();
   const adminItems = [
     {
-      path: "/admin/categories",
+      icon: HomeIcon,
+      label: "Dashboard",
+      path: "/admin",
+    },
+    {
+      icon: CategoryIcon,
       label: "Categories",
+      path: "/admin/categories",
     },
   ];
 
@@ -15,23 +22,21 @@ export function AdminLayout() {
     <section className={"min-h-screenMinusNavbar w-full"}>
       <aside
         className={
-          "w-adminSidebar fixed flex h-full flex-col gap-2 border-1 border-b-0 border-t-0 border-r-default/50 bg-background p-2 md:p-6"
+          "fixed flex h-full w-adminSidebar flex-col gap-2 border-1 border-b-0 border-t-0 border-r-default/50 bg-background p-2 md:p-6"
         }
       >
         {adminItems.map((item) => {
-          const { label, path } = item;
+          const { icon, label, path } = item;
           const isActive = pathname === path;
 
           return (
             <Link
-              className={`flex items-center justify-center gap-4 rounded-md p-2 text-lg text-foreground transition-all duration-75 ease-linear md:p-3 ${isActive ? "bg-primary/10 font-medium" : ""}`}
+              className={`flex items-center justify-center gap-3 rounded-md px-4 py-2 text-medium text-foreground transition-all duration-75 ease-linear md:justify-start md:px-4 md:py-3 ${isActive ? "bg-primary/10 font-medium" : "hover:bg-primary/5 hover:font-medium"} transition-all duration-75 ease-linear`}
               href={path}
               key={path}
             >
+              <div>{icon()}</div>
               <span className={"hidden md:block"}>{label}</span>
-              <div className={"md:hidden"}>
-                <CategoryIcon />
-              </div>
             </Link>
           );
         })}

--- a/src/shared/pages/layouts/AppLayout.tsx
+++ b/src/shared/pages/layouts/AppLayout.tsx
@@ -7,7 +7,7 @@ export function AppLayout() {
       <Navbar />
       <main
         className={
-          "mx-auto flex min-h-[calc(100dvh_-_88px)] max-w-screen-2xl items-center justify-center p-6"
+          "min-h-screenMinusNavbar mx-auto flex items-center justify-center"
         }
       >
         <Outlet />

--- a/src/shared/pages/routes/ProtectedRoute.tsx
+++ b/src/shared/pages/routes/ProtectedRoute.tsx
@@ -1,0 +1,23 @@
+import { Navigate } from "react-router-dom";
+import { PropsWithChildren } from "react";
+import { Role } from "@/modules/users/enums/role.enum.ts";
+import { useAuthStore } from "@auth/hooks/useAuthStore.ts";
+
+interface ProtectedRouteProps extends PropsWithChildren {
+  allowedRoles?: Role[];
+}
+
+export function ProtectedRoute({
+  allowedRoles,
+  children,
+}: ProtectedRouteProps) {
+  const { isAuthenticated, authResponse } = useAuthStore();
+  if (!isAuthenticated) return <Navigate to={"/auth/signin"} />;
+  if (!authResponse) return <Navigate to={"/auth/signin"} />;
+
+  if (allowedRoles && !allowedRoles.includes(authResponse.role)) {
+    return <Navigate to={"/"} />;
+  }
+
+  return children;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,6 +4,19 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Variables */
+:root {
+  --admin-sidebar-width: 20rem;
+
+  @media (width < 1024px) {
+     --admin-sidebar-width: 16rem;
+  }
+
+  @media (width < 768px) {
+     --admin-sidebar-width: 4rem;
+  }
+}
+
 .fadeInUp {
   animation: fadeInUp 0.4s ease;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,7 +13,7 @@ export default {
         raleway: ["Raleway", "sans-serif"],
       },
       spacing: {
-        "admin-sidebar": "var(--admin-sidebar-width)",
+        adminSidebar: "var(--admin-sidebar-width)",
         screenMinusNavbar: "calc(100dvh - 90px)",
       },
     },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,10 @@ export default {
       fontFamily: {
         raleway: ["Raleway", "sans-serif"],
       },
+      spacing: {
+        "admin-sidebar": "var(--admin-sidebar-width)",
+        screenMinusNavbar: "calc(100dvh - 90px)",
+      },
     },
   },
   plugins: [nextui()],


### PR DESCRIPTION
Ahora en el menú de navegación disponemos de un enlace _(solo se muestra al usuario cuyo rol sea admin)_ que nos redirige a un panel de administración. Ademas, cuenta con dos paginas básicas: el inicio del dashboard y el de las categorías.
Sirve como puntapié inicial para comenzar a gestionar los CRUD's de las entidades.

# Visualizacion
![image](https://github.com/user-attachments/assets/ffad9a73-797f-4851-8656-2d469f7e67c0)

