### PR TITLE
feat: manage categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
     "@nextui-org/react": "^2.4.6",
+    "@nextui-org/use-infinite-scroll": "^2.1.5",
     "@tanstack/react-query": "^5.53.3",
     "axios": "^1.7.7",
     "framer-motion": "^11.3.31",

--- a/src/modules/categories/categories.service.ts
+++ b/src/modules/categories/categories.service.ts
@@ -1,0 +1,36 @@
+import { httpClient } from "@/shared/lib/httpClient.ts";
+import { CategoryResponse } from "@/modules/categories/interfaces/responses/category-response.interface.ts";
+import { CreateCategoryRequest } from "@/modules/categories/interfaces/requests/create-category.interface.ts";
+import { Category } from "@/modules/categories/interfaces/responses/category.interface.ts";
+import { PaginationRequest } from "@/shared/interfaces/pagination/pagination-request.interface.ts";
+import { UpdateCategoryRequest } from "@/modules/categories/interfaces/requests/update-category.interface.ts";
+
+const CATEGORIES_URL = `${import.meta.env.VITE_BACKEND_URL}/api/v1/categories`;
+
+export async function getAllCategories(params: PaginationRequest) {
+  const response = await httpClient.get<CategoryResponse>(CATEGORIES_URL, {
+    params,
+  });
+  return response.data;
+}
+
+export async function deleteCategory(categoryId: string) {
+  await httpClient.delete(`${CATEGORIES_URL}/${categoryId}`);
+}
+
+export async function createCategory(params: CreateCategoryRequest) {
+  const response = await httpClient.post<Category>(CATEGORIES_URL, {
+    ...params,
+  });
+  return response.data;
+}
+
+export async function updateCategory(params: UpdateCategoryRequest) {
+  const response = await httpClient.put<Category>(
+    `${CATEGORIES_URL}/${params.categoryId}`,
+    {
+      ...params,
+    },
+  );
+  return response.data;
+}

--- a/src/modules/categories/components/CategoriesTable.tsx
+++ b/src/modules/categories/components/CategoriesTable.tsx
@@ -42,11 +42,11 @@ const columns = [
 ];
 
 export function CategoriesTable() {
-  const [currentPage, setCurrentPage] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
   const { data, isLoading } = useGetCategories({
     page: currentPage,
   });
-  const { mutate } = useDeleteCategory();
+  const { deleteCategory } = useDeleteCategory();
   const { onOpen, onClose, isOpen } = useDisclosure();
   const [editingCategory, setEditingCategory] = useState<Category | undefined>(
     undefined,
@@ -140,8 +140,12 @@ export function CategoriesTable() {
                 <TableActions
                   deleteContent={"Delete category"}
                   editContent={"Edit category"}
-                  onDelete={() => mutate(category.categoryId)}
+                  onDelete={() => deleteCategory(category.categoryId)}
                   onEdit={() => handleOnEdit(category)}
+                  confirmModalProps={{
+                    title: "Delete category",
+                    description: `Are you sure you want to delete the category ${category.name}?`,
+                  }}
                 />
               </TableCell>
             </TableRow>

--- a/src/modules/categories/components/CategoriesTable.tsx
+++ b/src/modules/categories/components/CategoriesTable.tsx
@@ -1,0 +1,161 @@
+import {
+  Button,
+  ButtonGroup,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  Pagination,
+  Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+  useDisclosure,
+} from "@nextui-org/react";
+import { TableActions } from "@/shared/components/ui/TableActions.tsx";
+import { useDeleteCategory } from "@/modules/categories/hooks/useDeleteCategory.ts";
+import { useMemo, useState } from "react";
+import { Category } from "@/modules/categories/interfaces/responses/category.interface.ts";
+import { EditCategoryForm } from "@/modules/categories/components/EditCategoryForm.tsx";
+import { useGetCategories } from "@/modules/categories/hooks/useGetCategories.ts";
+
+const columns = [
+  {
+    key: "name",
+    label: "NAME",
+  },
+  {
+    key: "description",
+    label: "DESCRIPTION",
+  },
+  {
+    key: "superCategory",
+    label: "SUPER CATEGORY",
+  },
+  {
+    key: "actions",
+    label: "ACTIONS",
+  },
+];
+
+export function CategoriesTable() {
+  const [currentPage, setCurrentPage] = useState(0);
+  const { data, isLoading } = useGetCategories({
+    page: currentPage,
+  });
+  const { mutate } = useDeleteCategory();
+  const { onOpen, onClose, isOpen } = useDisclosure();
+  const [editingCategory, setEditingCategory] = useState<Category | undefined>(
+    undefined,
+  );
+
+  function handleOnEdit(category: Category) {
+    setEditingCategory(category);
+    onOpen();
+  }
+
+  function handlePageChange(page: number) {
+    setCurrentPage(page);
+  }
+
+  const label = useMemo(() => {
+    if (!data) return;
+    return `Showing from ${data.pageable.offset + 1} to ${
+      data.pageable.offset + data.numberOfElements
+    } categories`;
+  }, [data]);
+
+  return (
+    <>
+      <Table
+        aria-label="List of categories"
+        bottomContentPlacement={"outside"}
+        bottomContent={
+          data && (
+            <div className="flex w-full flex-wrap items-center justify-center gap-4 sm:justify-between">
+              <Pagination
+                color="primary"
+                isCompact
+                onChange={(page) => handlePageChange(page)}
+                page={currentPage}
+                showControls
+                showShadow
+                size={"lg"}
+                total={data.totalPages}
+              />
+              <p className={"text-content4-foreground"}>{label}</p>
+              <ButtonGroup>
+                <Button
+                  isDisabled={data.first}
+                  onPress={() => handlePageChange(currentPage - 1)}
+                >
+                  Previous
+                </Button>
+                <Button
+                  isDisabled={data.last}
+                  onPress={() => handlePageChange(currentPage + 1)}
+                >
+                  Next
+                </Button>
+              </ButtonGroup>
+            </div>
+          )
+        }
+      >
+        <TableHeader columns={columns}>
+          {(column) => (
+            <TableColumn key={column.key}>{column.label}</TableColumn>
+          )}
+        </TableHeader>
+        <TableBody
+          items={data?.content || []}
+          loadingContent={
+            <div
+              className={
+                "flex h-full w-full flex-col items-center justify-center gap-2 bg-default p-4"
+              }
+            >
+              <Spinner />
+            </div>
+          }
+          loadingState={isLoading ? "loading" : "idle"}
+        >
+          {(category) => (
+            <TableRow key={category.categoryId}>
+              <TableCell>{category.name}</TableCell>
+              <TableCell>{category.description}</TableCell>
+              <TableCell>
+                <span
+                  className={`${!category.superCategoryName ? "text-content4-foreground" : ""}`}
+                >
+                  {category.superCategoryName || "No super category"}
+                </span>
+              </TableCell>
+              <TableCell>
+                <TableActions
+                  deleteContent={"Delete category"}
+                  editContent={"Edit category"}
+                  onDelete={() => mutate(category.categoryId)}
+                  onEdit={() => handleOnEdit(category)}
+                />
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+      {editingCategory && (
+        <Modal isOpen={isOpen} onClose={onClose} backdrop={"blur"} size={"lg"}>
+          <ModalContent>
+            <ModalHeader>Edit category</ModalHeader>
+            <ModalBody>
+              <EditCategoryForm category={editingCategory} onClose={onClose} />
+            </ModalBody>
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/modules/categories/components/CategoriesTable.tsx
+++ b/src/modules/categories/components/CategoriesTable.tsx
@@ -74,7 +74,8 @@ export function CategoriesTable() {
         aria-label="List of categories"
         bottomContentPlacement={"outside"}
         bottomContent={
-          data && (
+          data &&
+          data.content.length > 0 && (
             <div className="flex w-full flex-wrap items-center justify-center gap-4 sm:justify-between">
               <Pagination
                 color="primary"
@@ -111,6 +112,7 @@ export function CategoriesTable() {
           )}
         </TableHeader>
         <TableBody
+          emptyContent={"There are no categories to show"}
           items={data?.content || []}
           loadingContent={
             <div

--- a/src/modules/categories/components/CreateCategoryForm.tsx
+++ b/src/modules/categories/components/CreateCategoryForm.tsx
@@ -1,0 +1,72 @@
+import { useForm } from "react-hook-form";
+import {
+  CreateCategorySchema,
+  CreateCategorySchemaType,
+} from "@/modules/categories/schemas/create-category.schema.ts";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { InputField } from "@/shared/components/ui/InputField.tsx";
+import { Button, SelectItem } from "@nextui-org/react";
+import { useCreateCategory } from "@/modules/categories/hooks/useCreateCategory.ts";
+import { ControlledSelect } from "@/shared/components/ui/ControlledSelect.tsx";
+import { useGetCategories } from "@/modules/categories/hooks/useGetCategories.ts";
+
+interface CreateCategoryFormProps {
+  onClose: () => void;
+}
+
+export function CreateCategoryForm({ onClose }: CreateCategoryFormProps) {
+  const { control, handleSubmit } = useForm<CreateCategorySchemaType>({
+    resolver: zodResolver(CreateCategorySchema),
+  });
+  const { mutateAsync, isPending } = useCreateCategory();
+  const { data, isLoading } = useGetCategories({
+    pageSize: 99999999,
+  });
+
+  async function onSubmit(data: CreateCategorySchemaType) {
+    await mutateAsync(data);
+    onClose();
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={"flex flex-col gap-2"}>
+      <InputField<CreateCategorySchemaType>
+        control={control}
+        label={"Category name"}
+        name={"name"}
+        placeholder={"Type the category name"}
+      />
+
+      <InputField<CreateCategorySchemaType>
+        control={control}
+        label={"Category description"}
+        name={"description"}
+        placeholder={"Type the category description"}
+      />
+
+      <ControlledSelect
+        control={control}
+        isLoading={isLoading}
+        items={data?.content || []}
+        label={"Super category"}
+        name={"superCategoryId"}
+        placeholder={"Select a super category"}
+      >
+        {(category) => {
+          return (
+            <SelectItem key={category.categoryId}>{category.name}</SelectItem>
+          );
+        }}
+      </ControlledSelect>
+
+      <footer className={"my-4 flex justify-end gap-2"}>
+        <Button color="danger" variant="light" onPress={onClose}>
+          Close
+        </Button>
+        <Button color="primary" type={"submit"} isLoading={isPending}>
+          Save
+        </Button>
+      </footer>
+    </form>
+  );
+}

--- a/src/modules/categories/components/EditCategoryForm.tsx
+++ b/src/modules/categories/components/EditCategoryForm.tsx
@@ -1,0 +1,84 @@
+import { Category } from "@/modules/categories/interfaces/responses/category.interface.ts";
+import { useForm } from "react-hook-form";
+import {
+  UpdateCategorySchema,
+  UpdateCategorySchemaType,
+} from "@/modules/categories/schemas/update-category.schema.ts";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { InputField } from "@/shared/components/ui/InputField.tsx";
+import { Button, SelectItem } from "@nextui-org/react";
+import { useGetCategories } from "@/modules/categories/hooks/useGetCategories.ts";
+import { ControlledSelect } from "@/shared/components/ui/ControlledSelect.tsx";
+import { useUpdateCategory } from "@/modules/categories/hooks/useUpdateCategory.ts";
+
+interface EditCategoryFormProps {
+  category: Category;
+  onClose: () => void;
+}
+
+export function EditCategoryForm({ onClose, category }: EditCategoryFormProps) {
+  const { control, handleSubmit } = useForm<UpdateCategorySchemaType>({
+    resolver: zodResolver(UpdateCategorySchema),
+  });
+  const { data, isLoading } = useGetCategories({
+    pageSize: 99999999,
+  });
+  const { updateCategory, isUpdating } = useUpdateCategory();
+
+  async function onSubmit(data: UpdateCategorySchemaType) {
+    if (data.superCategoryId === "") {
+      data.superCategoryId = null;
+    }
+
+    await updateCategory({
+      categoryId: category.categoryId,
+      ...data,
+    });
+
+    onClose();
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={"flex flex-col gap-2"}>
+      <InputField<UpdateCategorySchemaType>
+        control={control}
+        defaultValue={category.name}
+        label={"Category name"}
+        name={"name"}
+        placeholder={"Type the category name"}
+      />
+
+      <InputField<UpdateCategorySchemaType>
+        control={control}
+        defaultValue={category.description}
+        label={"Category description"}
+        name={"description"}
+        placeholder={"Type the category description"}
+      />
+
+      <ControlledSelect
+        control={control}
+        defaultSelectedKeys={[category.superCategoryId || ""]}
+        isLoading={isLoading}
+        items={data?.content || []}
+        label={"Super category"}
+        name={"superCategoryId"}
+        placeholder={"Select a super category"}
+        defaultValue={<SelectItem key={"default"}>Hola</SelectItem>}
+      >
+        {(item) => {
+          return <SelectItem key={item.categoryId}>{item.name}</SelectItem>;
+        }}
+      </ControlledSelect>
+
+      <footer className={"my-4 flex justify-end gap-2"}>
+        <Button color="danger" variant="light" onPress={onClose}>
+          Close
+        </Button>
+        <Button color="primary" type={"submit"} isLoading={isUpdating}>
+          Save
+        </Button>
+      </footer>
+    </form>
+  );
+}

--- a/src/modules/categories/constants.ts
+++ b/src/modules/categories/constants.ts
@@ -1,0 +1,4 @@
+export const GET_CATEGORIES_KEY = "categories/get";
+export const DELETE_CATEGORY_KEY = "categories/delete";
+export const CREATE_CATEGORY_KEY = "categories/create";
+export const UPDATE_CATEGORY_KEY = "categories/update";

--- a/src/modules/categories/hooks/useCreateCategory.ts
+++ b/src/modules/categories/hooks/useCreateCategory.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createCategory } from "@/modules/categories/categories.service.ts";
+import {
+  CREATE_CATEGORY_KEY,
+  GET_CATEGORIES_KEY,
+} from "@/modules/categories/constants.ts";
+
+export function useCreateCategory() {
+  const queryClient = useQueryClient();
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: createCategory,
+    mutationKey: [CREATE_CATEGORY_KEY],
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [GET_CATEGORIES_KEY],
+      });
+    },
+  });
+
+  return { mutateAsync, isPending };
+}

--- a/src/modules/categories/hooks/useCreateCategory.ts
+++ b/src/modules/categories/hooks/useCreateCategory.ts
@@ -17,5 +17,8 @@ export function useCreateCategory() {
     },
   });
 
-  return { mutateAsync, isPending };
+  return {
+    createCategory: mutateAsync,
+    isCreating: isPending,
+  };
 }

--- a/src/modules/categories/hooks/useDeleteCategory.ts
+++ b/src/modules/categories/hooks/useDeleteCategory.ts
@@ -7,7 +7,7 @@ import { deleteCategory } from "@/modules/categories/categories.service.ts";
 
 export function useDeleteCategory() {
   const queryClient = useQueryClient();
-  const { mutate, isSuccess, isPending } = useMutation({
+  const { mutate } = useMutation({
     mutationFn: deleteCategory,
     mutationKey: [DELETE_CATEGORY_KEY],
     onSuccess: async () => {
@@ -17,5 +17,7 @@ export function useDeleteCategory() {
     },
   });
 
-  return { mutate, isSuccess, isPending };
+  return {
+    deleteCategory: mutate,
+  };
 }

--- a/src/modules/categories/hooks/useDeleteCategory.ts
+++ b/src/modules/categories/hooks/useDeleteCategory.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  DELETE_CATEGORY_KEY,
+  GET_CATEGORIES_KEY,
+} from "@/modules/categories/constants.ts";
+import { deleteCategory } from "@/modules/categories/categories.service.ts";
+
+export function useDeleteCategory() {
+  const queryClient = useQueryClient();
+  const { mutate, isSuccess, isPending } = useMutation({
+    mutationFn: deleteCategory,
+    mutationKey: [DELETE_CATEGORY_KEY],
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [GET_CATEGORIES_KEY],
+      });
+    },
+  });
+
+  return { mutate, isSuccess, isPending };
+}

--- a/src/modules/categories/hooks/useGetCategories.ts
+++ b/src/modules/categories/hooks/useGetCategories.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { GET_CATEGORIES_KEY } from "@/modules/categories/constants.ts";
+import { PaginationRequest } from "@/shared/interfaces/pagination/pagination-request.interface.ts";
+import { getAllCategories } from "@/modules/categories/categories.service.ts";
+
+export function useGetCategories(params: PaginationRequest) {
+  const { pageSize = 10, page = 0, ...rest } = params;
+  const { data, isLoading, isError } = useQuery({
+    queryFn: () =>
+      getAllCategories({
+        page: page - 1 < 0 ? page : page - 1,
+        pageSize,
+        ...rest,
+      }),
+    queryKey: [GET_CATEGORIES_KEY, page, pageSize],
+    staleTime: Infinity,
+  });
+
+  return { data, isLoading, isError };
+}

--- a/src/modules/categories/hooks/useGetCategories.ts
+++ b/src/modules/categories/hooks/useGetCategories.ts
@@ -5,14 +5,16 @@ import { getAllCategories } from "@/modules/categories/categories.service.ts";
 
 export function useGetCategories(params: PaginationRequest) {
   const { pageSize = 10, page = 0, ...rest } = params;
+  const fixedPage = page - 1 < 0 ? page : page - 1;
+
   const { data, isLoading, isError } = useQuery({
     queryFn: () =>
       getAllCategories({
-        page: page - 1 < 0 ? page : page - 1,
+        page: fixedPage,
         pageSize,
         ...rest,
       }),
-    queryKey: [GET_CATEGORIES_KEY, page, pageSize],
+    queryKey: [GET_CATEGORIES_KEY, fixedPage, pageSize],
     staleTime: Infinity,
   });
 

--- a/src/modules/categories/hooks/useInfiniteCategories.ts
+++ b/src/modules/categories/hooks/useInfiniteCategories.ts
@@ -1,0 +1,37 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { getAllCategories } from "@/modules/categories/categories.service.ts";
+import { GET_CATEGORIES_KEY } from "@/modules/categories/constants.ts";
+
+export function useInfiniteCategories() {
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    hasPreviousPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useInfiniteQuery({
+    queryKey: [GET_CATEGORIES_KEY],
+    queryFn: async (props) => {
+      return getAllCategories({
+        page: props.pageParam as number,
+        pageSize: 10,
+      });
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.last) return undefined;
+      return allPages.length;
+    },
+    staleTime: Infinity,
+  });
+
+  return {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    hasPreviousPage,
+    isFetchingNextPage,
+    isLoading,
+  };
+}

--- a/src/modules/categories/hooks/useUpdateCategory.ts
+++ b/src/modules/categories/hooks/useUpdateCategory.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  GET_CATEGORIES_KEY,
+  UPDATE_CATEGORY_KEY,
+} from "@/modules/categories/constants.ts";
+import { updateCategory } from "@/modules/categories/categories.service.ts";
+
+export function useUpdateCategory() {
+  const queryClient = useQueryClient();
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: updateCategory,
+    mutationKey: [UPDATE_CATEGORY_KEY],
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: [GET_CATEGORIES_KEY],
+      });
+    },
+  });
+
+  return {
+    updateCategory: mutateAsync,
+    isUpdating: isPending,
+  };
+}

--- a/src/modules/categories/interfaces/requests/create-category.interface.ts
+++ b/src/modules/categories/interfaces/requests/create-category.interface.ts
@@ -1,0 +1,4 @@
+export interface CreateCategoryRequest {
+  name: string;
+  description: string;
+}

--- a/src/modules/categories/interfaces/requests/update-category.interface.ts
+++ b/src/modules/categories/interfaces/requests/update-category.interface.ts
@@ -1,0 +1,6 @@
+export interface UpdateCategoryRequest {
+  categoryId: string;
+  description: string;
+  name: string;
+  superCategoryId?: string | null;
+}

--- a/src/modules/categories/interfaces/responses/category-response.interface.ts
+++ b/src/modules/categories/interfaces/responses/category-response.interface.ts
@@ -1,0 +1,4 @@
+import { Category } from "@/modules/categories/interfaces/responses/category.interface.ts";
+import { PaginatedResponse } from "@/shared/interfaces/pagination/paginated-response.interface.ts";
+
+export type CategoryResponse = PaginatedResponse<Category>;

--- a/src/modules/categories/interfaces/responses/category.interface.ts
+++ b/src/modules/categories/interfaces/responses/category.interface.ts
@@ -1,0 +1,7 @@
+export interface Category {
+  categoryId: string;
+  description: string;
+  name: string;
+  superCategoryName?: string | null;
+  superCategoryId: string | null;
+}

--- a/src/modules/categories/schemas/create-category.schema.ts
+++ b/src/modules/categories/schemas/create-category.schema.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const CreateCategorySchema = z.object({
+  name: z
+    .string({
+      required_error: "",
+    })
+    .max(20, {
+      message: "Name must be less than 20 characters",
+    }),
+  description: z
+    .string({
+      required_error: "",
+    })
+    .max(50, {
+      message: "Description must be less than 50 characters",
+    }),
+  superCategoryId: z.string().optional(),
+});
+
+export type CreateCategorySchemaType = z.infer<typeof CreateCategorySchema>;

--- a/src/modules/categories/schemas/update-category.schema.ts
+++ b/src/modules/categories/schemas/update-category.schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const UpdateCategorySchema = z.object({
+  name: z
+    .string({
+      required_error: "",
+    })
+    .min(1, {
+      message: "Name is required",
+    })
+    .max(20, {
+      message: "Name must be less than 20 characters",
+    }),
+  description: z
+    .string({
+      required_error: "",
+    })
+    .max(50, {
+      message: "Description must be less than 50 characters",
+    }),
+  superCategoryId: z.string().optional().nullable(),
+});
+
+export type UpdateCategorySchemaType = z.infer<typeof UpdateCategorySchema>;

--- a/src/providers/RoutesProvider.tsx
+++ b/src/providers/RoutesProvider.tsx
@@ -15,6 +15,7 @@ import { SignInPage } from "@/shared/pages/auth/SignInPage.tsx";
 import { SignUpPage } from "@/shared/pages/auth/SignUpPage.tsx";
 import { UnauthenticatedRoute } from "@/shared/pages/routes/UnauthenticatedRoute.tsx";
 import { CategoryAdminPage } from "@/shared/pages/admin/CategoryAdminPage.tsx";
+import { CreateCategoryPage } from "@/shared/pages/admin/CreateCategoryPage.tsx";
 
 export default function RoutesProvider() {
   const navigate = useNavigate();
@@ -33,7 +34,9 @@ export default function RoutesProvider() {
             }
           >
             <Route index element={<AdminPage />} />
-            <Route path={"categories"} element={<CategoryAdminPage />} />
+            <Route path={"categories"} element={<CategoryAdminPage />}>
+              <Route path={"create"} element={<CreateCategoryPage />} />
+            </Route>
           </Route>
         </Route>
         <Route

--- a/src/shared/components/icons/CategoryIcon.tsx
+++ b/src/shared/components/icons/CategoryIcon.tsx
@@ -13,22 +13,22 @@ export function CategoryIcon() {
       <path stroke="none" d="M0 0h24v24H0z" fill="none" />
       <path
         d="M10 3h-6a1 1 0 0 0 -1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1 -1v-6a1 1 0 0 0 -1 -1z"
-        stroke-width="0"
+        strokeWidth="0"
         fill="#53535B"
       />
       <path
         d="M20 3h-6a1 1 0 0 0 -1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1 -1v-6a1 1 0 0 0 -1 -1z"
-        stroke-width="0"
+        strokeWidth="0"
         fill="#53535B"
       />
       <path
         d="M10 13h-6a1 1 0 0 0 -1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1 -1v-6a1 1 0 0 0 -1 -1z"
-        stroke-width="0"
+        strokeWidth="0"
         fill="#53535B"
       />
       <path
         d="M17 13a4 4 0 1 1 -3.995 4.2l-.005 -.2l.005 -.2a4 4 0 0 1 3.995 -3.8z"
-        stroke-width="0"
+        strokeWidth="0"
         fill="#53535B"
       />
     </svg>

--- a/src/shared/components/icons/DeleteIcon.tsx
+++ b/src/shared/components/icons/DeleteIcon.tsx
@@ -1,0 +1,54 @@
+import { ComponentProps } from "react";
+
+type DeleteIconProps = ComponentProps<"svg">;
+
+export function DeleteIcon(props: DeleteIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      height="1em"
+      role="presentation"
+      viewBox="0 0 20 20"
+      width="1em"
+      {...props}
+    >
+      <path
+        d="M17.5 4.98332C14.725 4.70832 11.9333 4.56665 9.15 4.56665C7.5 4.56665 5.85 4.64998 4.2 4.81665L2.5 4.98332"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+      <path
+        d="M7.08331 4.14169L7.26665 3.05002C7.39998 2.25835 7.49998 1.66669 8.90831 1.66669H11.0916C12.5 1.66669 12.6083 2.29169 12.7333 3.05835L12.9166 4.14169"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+      <path
+        d="M15.7084 7.61664L15.1667 16.0083C15.075 17.3166 15 18.3333 12.675 18.3333H7.32502C5.00002 18.3333 4.92502 17.3166 4.83335 16.0083L4.29169 7.61664"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+      <path
+        d="M8.60834 13.75H11.3833"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+      <path
+        d="M7.91669 10.4167H12.0834"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}

--- a/src/shared/components/icons/EditIcon.tsx
+++ b/src/shared/components/icons/EditIcon.tsx
@@ -1,0 +1,43 @@
+import { ComponentProps } from "react";
+
+type EditIconProps = ComponentProps<"svg">;
+
+export function EditIcon(props: EditIconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      height="1em"
+      role="presentation"
+      viewBox="0 0 20 20"
+      width="1em"
+      {...props}
+    >
+      <path
+        d="M11.05 3.00002L4.20835 10.2417C3.95002 10.5167 3.70002 11.0584 3.65002 11.4334L3.34169 14.1334C3.23335 15.1084 3.93335 15.775 4.90002 15.6084L7.58335 15.15C7.95835 15.0834 8.48335 14.8084 8.74168 14.525L15.5834 7.28335C16.7667 6.03335 17.3 4.60835 15.4583 2.86668C13.625 1.14168 12.2334 1.75002 11.05 3.00002Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeMiterlimit={10}
+        strokeWidth={1.5}
+      />
+      <path
+        d="M9.90833 4.20831C10.2667 6.50831 12.1333 8.26665 14.45 8.49998"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeMiterlimit={10}
+        strokeWidth={1.5}
+      />
+      <path
+        d="M2.5 18.3333H17.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeMiterlimit={10}
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}

--- a/src/shared/components/icons/PlusIcon.tsx
+++ b/src/shared/components/icons/PlusIcon.tsx
@@ -1,0 +1,17 @@
+import { ComponentProps } from "react";
+
+type PlusIconProps = ComponentProps<"svg">;
+export function PlusIcon(props: PlusIconProps) {
+  return (
+    <svg
+      fill="#000000"
+      height="32"
+      viewBox="0 0 256 256"
+      width="32"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"></path>
+    </svg>
+  );
+}

--- a/src/shared/components/ui/ConfirmModal.tsx
+++ b/src/shared/components/ui/ConfirmModal.tsx
@@ -1,0 +1,39 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@nextui-org/react";
+
+interface ConfirmModalProps {
+  description: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+}
+
+export function ConfirmModal(props: ConfirmModalProps) {
+  const { description, isOpen, onClose, onConfirm, title } = props;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size={"lg"} backdrop={"blur"}>
+      <ModalContent>
+        <ModalHeader>{title}</ModalHeader>
+        <ModalBody>
+          <p>{description}</p>
+        </ModalBody>
+        <ModalFooter>
+          <Button color="danger" variant="light" onPress={onClose}>
+            Cancel
+          </Button>
+          <Button color="primary" onPress={onConfirm}>
+            Delete
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/shared/components/ui/ControlledSelect.tsx
+++ b/src/shared/components/ui/ControlledSelect.tsx
@@ -1,0 +1,47 @@
+import {
+  Control,
+  Controller,
+  ControllerProps,
+  FieldValues,
+} from "react-hook-form";
+import { Select, SelectProps } from "@nextui-org/react";
+import React from "react";
+
+type ControlledSelectProps<T extends FieldValues> = Omit<
+  ControllerProps,
+  "render" | "control"
+> &
+  Omit<SelectProps, "children"> & {
+    items: T[];
+    children: (item: T) => React.ReactElement;
+    control: Control<any>;
+  };
+
+export function ControlledSelect<T extends FieldValues>(
+  props: ControlledSelectProps<T>,
+) {
+  const controllerProps = {
+    control: props.control,
+    name: props.name,
+    rules: props.rules,
+  };
+
+  return (
+    <Controller
+      render={({ fieldState, field }) => (
+        <Select
+          className={"w-full"}
+          errorMessage={fieldState.error?.message}
+          isInvalid={fieldState.invalid}
+          {...props}
+          {...field}
+        >
+          {props.items.map((item) => {
+            return props.children(item);
+          })}
+        </Select>
+      )}
+      {...controllerProps}
+    />
+  );
+}

--- a/src/shared/components/ui/TableActions.tsx
+++ b/src/shared/components/ui/TableActions.tsx
@@ -1,16 +1,23 @@
-import { Tooltip } from "@nextui-org/react";
+import { Tooltip, useDisclosure } from "@nextui-org/react";
 import { DeleteIcon } from "@/shared/components/icons/DeleteIcon.tsx";
 import { EditIcon } from "@/shared/components/icons/EditIcon.tsx";
+import { ConfirmModal } from "@/shared/components/ui/ConfirmModal.tsx";
 
 interface TableActionsProps {
   deleteContent: string;
   editContent: string;
   onDelete: () => void;
   onEdit: () => void;
+  confirmModalProps: {
+    title: string;
+    description: string;
+  };
 }
 
 export function TableActions(props: TableActionsProps) {
-  const { deleteContent, editContent, onDelete, onEdit } = props;
+  const { deleteContent, editContent, onDelete, onEdit, confirmModalProps } =
+    props;
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <div className="flex items-center gap-4">
@@ -25,11 +32,17 @@ export function TableActions(props: TableActionsProps) {
       <Tooltip color="danger" content={deleteContent} delay={0} closeDelay={0}>
         <button
           className="cursor-pointer text-lg text-danger active:opacity-50"
-          onClick={onDelete}
+          onClick={onOpen}
         >
           <DeleteIcon />
         </button>
       </Tooltip>
+      <ConfirmModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onConfirm={onDelete}
+        {...confirmModalProps}
+      />
     </div>
   );
 }

--- a/src/shared/components/ui/TableActions.tsx
+++ b/src/shared/components/ui/TableActions.tsx
@@ -1,0 +1,35 @@
+import { Tooltip } from "@nextui-org/react";
+import { DeleteIcon } from "@/shared/components/icons/DeleteIcon.tsx";
+import { EditIcon } from "@/shared/components/icons/EditIcon.tsx";
+
+interface TableActionsProps {
+  deleteContent: string;
+  editContent: string;
+  onDelete: () => void;
+  onEdit: () => void;
+}
+
+export function TableActions(props: TableActionsProps) {
+  const { deleteContent, editContent, onDelete, onEdit } = props;
+
+  return (
+    <div className="flex items-center gap-4">
+      <Tooltip content={editContent} delay={0} closeDelay={0}>
+        <button
+          className="cursor-pointer text-lg text-default-400 active:opacity-50"
+          onClick={onEdit}
+        >
+          <EditIcon />
+        </button>
+      </Tooltip>
+      <Tooltip color="danger" content={deleteContent} delay={0} closeDelay={0}>
+        <button
+          className="cursor-pointer text-lg text-danger active:opacity-50"
+          onClick={onDelete}
+        >
+          <DeleteIcon />
+        </button>
+      </Tooltip>
+    </div>
+  );
+}

--- a/src/shared/hooks/useZodForm.ts
+++ b/src/shared/hooks/useZodForm.ts
@@ -1,0 +1,13 @@
+import { useForm, UseFormProps, UseFormReturn } from "react-hook-form";
+import { z, ZodType } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+export function useZodForm<T extends ZodType>(
+  schema: T,
+  options?: Omit<UseFormProps<z.infer<T>>, "resolver">,
+): UseFormReturn<z.infer<T>> {
+  return useForm<z.infer<T>>({
+    ...options,
+    resolver: zodResolver(schema),
+  });
+}

--- a/src/shared/interfaces/pagination/pagination-request.interface.ts
+++ b/src/shared/interfaces/pagination/pagination-request.interface.ts
@@ -1,5 +1,5 @@
 export interface PaginationRequest {
-  pageNumber?: number;
+  page?: number;
   pageSize?: number;
   sortAttribute?: string;
   sortOrder?: "asc" | "desc";

--- a/src/shared/pages/admin/CategoryAdminPage.tsx
+++ b/src/shared/pages/admin/CategoryAdminPage.tsx
@@ -1,11 +1,28 @@
+import { Button, Link } from "@nextui-org/react";
+import { PlusIcon } from "@/shared/components/icons/PlusIcon.tsx";
 import { Title } from "@/shared/components/typography/Title.tsx";
+import { Outlet } from "react-router-dom";
+import { CategoriesTable } from "@/modules/categories/components/CategoriesTable.tsx";
 
 export function CategoryAdminPage() {
   return (
-    <div className={"p-6"}>
-      <header className={"items- center flex w-full justify-between gap-2"}>
+    <div className={"flex min-h-screenMinusNavbar flex-col gap-6 p-6"}>
+      <header
+        className={"flex w-full flex-wrap items-center justify-between gap-2"}
+      >
         <Title>List of categories</Title>
+        <Button
+          as={Link}
+          href={"/admin/categories/create"}
+          color={"primary"}
+          className={"w-full sm:w-auto"}
+          startContent={<PlusIcon width={18} height={18} fill={"white"} />}
+        >
+          Create new
+        </Button>
       </header>
+      <CategoriesTable />
+      <Outlet />
     </div>
   );
 }

--- a/src/shared/pages/admin/CreateCategoryPage.tsx
+++ b/src/shared/pages/admin/CreateCategoryPage.tsx
@@ -1,0 +1,22 @@
+import { Modal, ModalBody, ModalContent, ModalHeader } from "@nextui-org/react";
+import { useNavigate } from "react-router-dom";
+import { CreateCategoryForm } from "@/modules/categories/components/CreateCategoryForm.tsx";
+
+export function CreateCategoryPage() {
+  const navigate = useNavigate();
+
+  function onClose() {
+    navigate("/admin/categories");
+  }
+
+  return (
+    <Modal isOpen onClose={onClose} backdrop={"blur"} size={"lg"}>
+      <ModalContent>
+        <ModalHeader>Create a new category</ModalHeader>
+        <ModalBody>
+          <CreateCategoryForm onClose={onClose} />
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}


### PR DESCRIPTION
Se ha implementado la funcionalidad completa para **registrar, editar y eliminar categorías**. Para cada acción del CRUD se creó un custom hook que gestiona la lógica utilizando React Query junto a las funciones definidas en el servicio correspondiente.

Se optó por **invalidar las queries**, lo que provoca un **refetch** de los datos cada vez que se realiza una petición que requiera actualizar la información. Aunque, en el caso de una eliminación, podríamos simplemente filtrar las categorías excluyendo la eliminada, también es necesario actualizar datos como el número total de elementos y páginas. De manera similar, en una adición, podríamos agregar la nueva entidad directamente a la lista, pero esto podría desalinear el orden de los datos y exigir el uso de un estado global para gestionar las categorías.

Aprovechamos la simplicidad que ofrece React Query para realizar refetch de los datos, lo que nos asegura consistencia sin la complejidad de mantener un estado global replicado. De todas formas espero sus opiniones.

# Deuda técnica
- En el ControlledSelect, el atributo **Control** está tipado con any en el tipo genérico, al tratarse de un componente externo, es complejo poder tiparlo correctamente.
- En los **Select** correspondientes a la creación y actualización de las categorias, esta **hardcodeado** el pageSize con un valor muy alto con la intención de que nos traiga todos las categorías registradas. Podria solventarse utilizando un **scroll infinito** pero esto me hace pensar dos cosas:
    - Si tengo una tabla de categorías que hace una petición inicial, al darle click al botón para crear uno nuevo, también se hará otra petición para mostrar las categorías iniciales. Ya que no podemos utilizar el **useQuery** en ambos casos, se necesita del **useInfiniteQuery** para el scroll infinito.
    - En el actualizar categoría, como haríamos para seleccionar por defecto la super categoria? Ya que, si no se encuentra en el la pagina actual, no lo podemos mostrar ni sabemos de su existencia. Acá estamos limitados al componente Select ya hecho, porque se me había ocurrido crear un SelectItem primero de todo con los valores de la super categoría, pero no es posible, ya que no me permite renderizar cosas fuera del bucle.

![image](https://github.com/user-attachments/assets/1dade9c0-6a7e-4f80-929e-d9939e5acc7b)
![image](https://github.com/user-attachments/assets/be08fd56-cc65-41b4-90e6-469c088bfe02)
![image](https://github.com/user-attachments/assets/22b735f9-3096-4521-bb98-9bac7eefe909)
