### PR TITLE
feat: resend expired activation

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -17,6 +17,15 @@ export const activateUser = async (params: ActivateUserRequest) => {
   );
 };
 
+export async function sendNewActivationToken(params: {
+  activationToken: string;
+}) {
+  await httpClient.post<void>(
+    `${BACKEND_URL}/api/v1/users/send-new-activation-token`,
+    params,
+  );
+}
+
 export async function signUpUser(params: SignUpRequest) {
   await httpClient.post(`${BACKEND_URL}/auth/signup`, params);
 }

--- a/src/modules/auth/hooks/useActivateUser.ts
+++ b/src/modules/auth/hooks/useActivateUser.ts
@@ -6,7 +6,6 @@ import { toast } from "sonner";
 export function useActivateUser() {
   const navigate = useNavigate();
   const { isError, isPending, isSuccess, mutate } = useMutation({
-    mutationKey: [""],
     mutationFn: activateUser,
     onSuccess: () => {
       toast.success("Account activated successfully", { duration: 3000 });

--- a/src/modules/auth/hooks/useActivateUser.ts
+++ b/src/modules/auth/hooks/useActivateUser.ts
@@ -1,0 +1,23 @@
+import { useNavigate } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { activateUser } from "@auth/auth.service.ts";
+import { toast } from "sonner";
+
+export function useActivateUser() {
+  const navigate = useNavigate();
+  const { isError, isPending, isSuccess, mutate } = useMutation({
+    mutationKey: [""],
+    mutationFn: activateUser,
+    onSuccess: () => {
+      toast.success("Account activated successfully", { duration: 3000 });
+      navigate("/auth/signin", { replace: true });
+    },
+  });
+
+  return {
+    mutate,
+    isPending,
+    isError,
+    isSuccess,
+  };
+}

--- a/src/modules/auth/hooks/useActivateUser.ts
+++ b/src/modules/auth/hooks/useActivateUser.ts
@@ -15,9 +15,9 @@ export function useActivateUser() {
   });
 
   return {
-    mutate,
-    isPending,
-    isError,
-    isSuccess,
+    activateUserMutate: mutate,
+    activateUserIsPending: isPending,
+    activateUserIsError: isError,
+    activateUserIsSuccess: isSuccess,
   };
 }

--- a/src/modules/auth/hooks/useSendNewActivationToken.ts
+++ b/src/modules/auth/hooks/useSendNewActivationToken.ts
@@ -13,8 +13,8 @@ export function useSendNewActivationToken() {
   });
 
   return {
-    mutate,
-    isSuccess,
-    isError,
+    sendNewTokenMutate: mutate,
+    sendNewTokenIsSuccess: isSuccess,
+    sendNewTokenIsError: isError,
   };
 }

--- a/src/modules/auth/hooks/useSendNewActivationToken.ts
+++ b/src/modules/auth/hooks/useSendNewActivationToken.ts
@@ -1,0 +1,20 @@
+import { sendNewActivationToken } from "@auth/auth.service.ts";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+export function useSendNewActivationToken() {
+  const navigate = useNavigate();
+  const { mutate, isSuccess, isError } = useMutation({
+    mutationKey: [""],
+    mutationFn: sendNewActivationToken,
+    onSuccess: () => {
+      navigate("/auth/activation-email-resent", { replace: true });
+    },
+  });
+
+  return {
+    mutate,
+    isSuccess,
+    isError,
+  };
+}

--- a/src/modules/auth/hooks/useSendNewActivationToken.ts
+++ b/src/modules/auth/hooks/useSendNewActivationToken.ts
@@ -5,7 +5,6 @@ import { useNavigate } from "react-router-dom";
 export function useSendNewActivationToken() {
   const navigate = useNavigate();
   const { mutate, isSuccess, isError } = useMutation({
-    mutationKey: [""],
     mutationFn: sendNewActivationToken,
     onSuccess: () => {
       navigate("/auth/activation-email-resent", { replace: true });

--- a/src/shared/pages/auth/ActivateUserPage.tsx
+++ b/src/shared/pages/auth/ActivateUserPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Link } from "@nextui-org/react";
+import { Button } from "@nextui-org/react";
 import { useSearchParams } from "react-router-dom";
 
 import { Title } from "@/shared/components/typography/Title.tsx";
@@ -48,13 +48,15 @@ export function ActivateUserPage() {
         Activate account
       </Button>
       <div className={"text-center"}>
-        <Link
+        <Button
+          className={
+            "cursor-pointer border-none bg-transparent p-0 text-purple-500 underline"
+          }
           isDisabled={sendNewTokenIsSuccess || sendNewTokenIsError}
-          color={"secondary"}
-          onPress={handleSendNewActivationToken}
+          onClick={handleSendNewActivationToken}
         >
           Is your activation token expired? Click here to regenerate it.
-        </Link>
+        </Button>
       </div>
     </div>
   );

--- a/src/shared/pages/auth/ActivateUserPage.tsx
+++ b/src/shared/pages/auth/ActivateUserPage.tsx
@@ -8,17 +8,14 @@ import { useSendNewActivationToken } from "@auth/hooks/useSendNewActivationToken
 export function ActivateUserPage() {
   const [searchParams] = useSearchParams();
   const {
-    mutate: activateUserMutate,
-    isPending: activateUserIsPending,
-    isError: activateUserIsError,
-    isSuccess: activateUserIsSuccess,
+    activateUserMutate,
+    activateUserIsPending,
+    activateUserIsError,
+    activateUserIsSuccess,
   } = useActivateUser();
 
-  const {
-    mutate: sendNewTokenMutate,
-    isSuccess: sendNewTokenIsSuccess,
-    isError: sendNewTokenIsError,
-  } = useSendNewActivationToken();
+  const { sendNewTokenMutate, sendNewTokenIsSuccess, sendNewTokenIsError } =
+    useSendNewActivationToken();
 
   async function handleActivate() {
     const userId = searchParams.get("userId");


### PR DESCRIPTION
Se agregó una nueva funcionalidad para permitirle a los usuarios solicitar un nuevo token de activación en caso de que el suyo esté expirado. Esta funcionalidad estará disponible en la pantalla de **activación de usuario** (#4) con un _link_. La idea es que si el usuario ve que su token está expirado, en la misma pantalla tenga la posibilidad de solicitar uno nuevo.

![sendnewactivation](https://github.com/user-attachments/assets/1b93c8e8-e91c-4b05-a0ff-b3a0d5bf0e96)

Me tomé también la libertad de mover la activación del usuario a un hook personalizado, sólo porque vamos a tener dos mutates en la misma página y está bueno (calculo) que cada una tenga su hook y su nombre.

## Deuda técnica

En un futuro estaría bueno darle la posibilidad al usuario de que solicite por otro lado un nuevo token si este está expirado. Probablemente en el AuthFooter al lado de lo que ya tenemos se me ocurre. En tal caso, la request deberá ser distinta a la de esta PR porque el usuario, se supone, no tendrá su token. A esto lo dejo como deuda técnica (si alguien quiere hacerlo hoy domingo estoy encantadísimo).