### PR TITLE
fix: handle invalid pages in auth endpoints

### DIFF
--- a/src/providers/RoutesProvider.tsx
+++ b/src/providers/RoutesProvider.tsx
@@ -61,6 +61,8 @@ export default function RoutesProvider() {
             </UnauthenticatedRoute>
           }
         >
+          <Route path={"*"} element={<Navigate to="signin" replace />} />
+          <Route path={""} element={<Navigate to="signin" replace />} />
           <Route path={"signup"} element={<SignUpPage />} />
           <Route path={"signin"} element={<SignInPage />} />
           <Route path={"activate"} element={<ActivateUserPage />} />


### PR DESCRIPTION
En vez de hacer que redirija al not found, hago que vaya al signin.
Si ponemos algo como /auth/ va al /auth/signin
/auth/sign -> /auth/signin