### PR TITLE
ref: implement allowEdit and allowDelete attributes for table actions

### DIFF
--- a/src/modules/categories/components/CategoriesTable.tsx
+++ b/src/modules/categories/components/CategoriesTable.tsx
@@ -120,6 +120,8 @@ export function CategoriesTable() {
                     title: "Delete category",
                     description: `Are you sure you want to delete the category ${category.name}?`,
                   }}
+                  allowEdit
+                  allowDelete
                 />
               </TableCell>
             </TableRow>

--- a/src/modules/products/components/ProductsTable.tsx
+++ b/src/modules/products/components/ProductsTable.tsx
@@ -150,7 +150,7 @@ export function ProductsTable() {
                 deleteContent={"Delete product"}
                 editContent={"Edit product"}
                 onDelete={() => handleDelete(product.productId)}
-                onEdit={console.log}
+                allowDelete
               />
             </TableCell>
           </TableRow>

--- a/src/modules/sizes/components/SizesTable.tsx
+++ b/src/modules/sizes/components/SizesTable.tsx
@@ -103,6 +103,8 @@ export function SizesTable() {
                     title: "Delete size",
                     description: `Are you sure you want to delete the size ${size.name}?`,
                   }}
+                  allowEdit
+                  allowDelete
                 />
               </TableCell>
             </TableRow>

--- a/src/shared/components/ui/TableActions.tsx
+++ b/src/shared/components/ui/TableActions.tsx
@@ -9,17 +9,22 @@ import {
 interface TableActionsProps {
   deleteContent: string;
   editContent: string;
-  onDelete: () => Promise<void>;
-  onEdit: () => void;
+  onDelete?: () => Promise<void>;
+  onEdit?: () => void;
   confirmModalProps: Omit<ConfirmModalProps, "onConfirm">;
+  allowEdit?: boolean;
+  allowDelete?: boolean;
 }
 
 export function TableActions(props: TableActionsProps) {
   const { deleteContent, editContent, onDelete, onEdit, confirmModalProps } =
     props;
   const { showConfirmModal } = useConfirmModal();
+  const { allowEdit = false, allowDelete = false } = props;
 
   function handleDelete() {
+    if (!onDelete) return;
+
     showConfirmModal({
       description: confirmModalProps.description,
       onConfirm: onDelete,
@@ -29,22 +34,32 @@ export function TableActions(props: TableActionsProps) {
 
   return (
     <div className="flex items-center gap-4">
-      <Tooltip content={editContent} delay={0} closeDelay={0}>
-        <button
-          className="cursor-pointer text-lg text-default-400 active:opacity-50"
-          onClick={onEdit}
+      {allowEdit && (
+        <Tooltip content={editContent} delay={0} closeDelay={0}>
+          <button
+            className="cursor-pointer text-lg text-default-400 active:opacity-50"
+            onClick={onEdit}
+          >
+            <EditIcon />
+          </button>
+        </Tooltip>
+      )}
+
+      {allowDelete && (
+        <Tooltip
+          color="danger"
+          content={deleteContent}
+          delay={0}
+          closeDelay={0}
         >
-          <EditIcon />
-        </button>
-      </Tooltip>
-      <Tooltip color="danger" content={deleteContent} delay={0} closeDelay={0}>
-        <button
-          className="cursor-pointer text-lg text-danger active:opacity-50"
-          onClick={handleDelete}
-        >
-          <DeleteIcon />
-        </button>
-      </Tooltip>
+          <button
+            className="cursor-pointer text-lg text-danger active:opacity-50"
+            onClick={handleDelete}
+          >
+            <DeleteIcon />
+          </button>
+        </Tooltip>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Solución provisoria para poder elegir si queremos habilitar la edición y la eliminación en las acciones de las tablas. Eventualmente no se necesitará hacer esto ya que se supone que todas las tablas en las que usemos estas acciones deben poder editarse y eliminarse.