### PR TITLE
fix: implement optional to null

### DIFF
--- a/src/modules/categories/interfaces/requests/create-category.interface.ts
+++ b/src/modules/categories/interfaces/requests/create-category.interface.ts
@@ -1,4 +1,4 @@
 export interface CreateCategoryRequest {
   name: string;
-  description?: string | null;
+  description: string | null;
 }

--- a/src/modules/categories/interfaces/requests/update-category.interface.ts
+++ b/src/modules/categories/interfaces/requests/update-category.interface.ts
@@ -1,6 +1,6 @@
 export interface UpdateCategoryRequest {
   categoryId: string;
-  description?: string | null;
+  description: string | null;
   name: string;
-  superCategoryId?: string | null;
+  superCategoryId: string | null;
 }

--- a/src/modules/categories/interfaces/responses/category.interface.ts
+++ b/src/modules/categories/interfaces/responses/category.interface.ts
@@ -2,6 +2,6 @@ export interface Category {
   categoryId: string;
   description: string | null;
   name: string;
-  superCategoryName?: string | null;
+  superCategoryName: string | null;
   superCategoryId: string | null;
 }

--- a/src/modules/categories/schemas/create-category.schema.ts
+++ b/src/modules/categories/schemas/create-category.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { optionalToNull } from "@/shared/utils/optionalToNull.ts";
 
 export const CreateCategorySchema = z.object({
   name: z
@@ -14,8 +15,8 @@ export const CreateCategorySchema = z.object({
       message: "Description must be less than 50 characters",
     })
     .optional()
-    .nullable(),
-  superCategoryId: z.string().optional(),
+    .transform(optionalToNull),
+  superCategoryId: z.string().optional().transform(optionalToNull),
 });
 
 export type CreateCategorySchemaType = z.infer<typeof CreateCategorySchema>;

--- a/src/modules/categories/schemas/update-category.schema.ts
+++ b/src/modules/categories/schemas/update-category.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { optionalToNull } from "@/shared/utils/optionalToNull.ts";
 
 export const UpdateCategorySchema = z.object({
   name: z
@@ -17,8 +18,8 @@ export const UpdateCategorySchema = z.object({
       message: "Description must be less than 50 characters",
     })
     .optional()
-    .nullable(),
-  superCategoryId: z.string().optional().nullable(),
+    .transform(optionalToNull),
+  superCategoryId: z.string().optional().transform(optionalToNull),
 });
 
 export type UpdateCategorySchemaType = z.infer<typeof UpdateCategorySchema>;

--- a/src/modules/products/components/ProductCard.tsx
+++ b/src/modules/products/components/ProductCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Product } from "../interfaces/product-response.interface";
+import { Product } from "../interfaces/responses/product-response.interface.ts";
 import { Image } from "@nextui-org/react";
 
 interface ProductCardProps {

--- a/src/modules/products/components/ProductsTable.tsx
+++ b/src/modules/products/components/ProductsTable.tsx
@@ -127,7 +127,7 @@ export function ProductsTable() {
             </TableCell>
             <TableCell>
               <span className={"line-clamp-2 max-w-fit"}>
-                {product.description ?? (
+                {product.description || (
                   <p className="text-content4-foreground">No description</p>
                 )}
               </span>
@@ -155,7 +155,7 @@ export function ProductsTable() {
 
             <TableCell>{product.sizeName}</TableCell>
             <TableCell>
-              {product.variantOfName ?? (
+              {product.variantOfName || (
                 <span className={"text-gray-400"}>No variant</span>
               )}
             </TableCell>

--- a/src/modules/products/interfaces/requests/create-product.interface.ts
+++ b/src/modules/products/interfaces/requests/create-product.interface.ts
@@ -1,12 +1,12 @@
 interface CreateProductRequest {
   categoryId: string;
   color: string;
-  description: string;
+  description: string | null;
   name: string;
   price: number;
   sizeId: string;
   stock: number;
-  variantOfId?: string | null;
+  variantOfId: string | null;
 }
 
 export interface CreateProductParams {

--- a/src/modules/products/schemas/create-product.schema.ts
+++ b/src/modules/products/schemas/create-product.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { optionalToNull } from "@/shared/utils/optionalToNull.ts";
 
 export const CreateProductSchema = z.object({
   name: z
@@ -16,7 +17,8 @@ export const CreateProductSchema = z.object({
     .max(80, {
       message: "Description must be less than 80 characters.",
     })
-    .optional(),
+    .optional()
+    .transform(optionalToNull),
   stock: z
     .number({
       coerce: true,
@@ -56,7 +58,7 @@ export const CreateProductSchema = z.object({
     .min(1, {
       message: "",
     }),
-  variantOfId: z.string().optional().nullable(),
+  variantOfId: z.string().optional().transform(optionalToNull),
   images: z
     .array(z.instanceof(File), {
       required_error: "",

--- a/src/modules/sizes/interfaces/responses/size.interface.ts
+++ b/src/modules/sizes/interfaces/responses/size.interface.ts
@@ -1,5 +1,5 @@
 export interface Size {
   sizeId: string;
   name: string;
-  description?: string | null;
+  description: string | null;
 }

--- a/src/modules/sizes/schemas/create-size.schema.ts
+++ b/src/modules/sizes/schemas/create-size.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { optionalToNull } from "@/shared/utils/optionalToNull.ts";
 
 export const CreateSizeSchema = z.object({
   name: z
@@ -13,7 +14,8 @@ export const CreateSizeSchema = z.object({
     .max(50, {
       message: "Description must be less than 50 characters",
     })
-    .optional(),
+    .optional()
+    .transform(optionalToNull),
 });
 
 export type CreateSizeSchemaType = z.infer<typeof CreateSizeSchema>;

--- a/src/modules/sizes/schemas/update-size.schema.ts
+++ b/src/modules/sizes/schemas/update-size.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { optionalToNull } from "@/shared/utils/optionalToNull.ts";
 
 export const UpdateSizeSchema = z.object({
   name: z
@@ -12,13 +13,12 @@ export const UpdateSizeSchema = z.object({
       message: "Name must be less than 20 characters",
     }),
   description: z
-    .string({
-      required_error: "",
-    })
+    .string()
     .max(50, {
       message: "Description must be less than 50 characters",
     })
-    .optional(),
+    .optional()
+    .transform(optionalToNull),
 });
 
 export type UpdateSizeSchemaType = z.infer<typeof UpdateSizeSchema>;

--- a/src/shared/utils/optionalToNull.ts
+++ b/src/shared/utils/optionalToNull.ts
@@ -1,0 +1,2 @@
+export const optionalToNull = (value: string | undefined) =>
+  !value ? null : value;


### PR DESCRIPTION
La idea es eliminar el uso de _undefined_. Ahora, manejamos estos atributos con un valor **null**, nos ahorramos el tener que definir 3 tipos de datos en estos atributos (undefined | null | string, por ejemplo)

Ejemplo
- No se ingresa nada en un campo llamado descripción, entonces, cuando se hace el submit, su valor sera null.
- Se ingresa algo y se borra, este comportamiento llevara a que se tenga como valor un string vacío, con esta implementacion pasaría a ser null.

Cabe recalcar que esto solo debería aplicarse en atributos que tengan un **.optional()**