### PR TITLE
feat: view deleted sizes

### DIFF
--- a/src/modules/categories/components/CategoriesTable.tsx
+++ b/src/modules/categories/components/CategoriesTable.tsx
@@ -12,7 +12,7 @@ import {
   TableRow,
   useDisclosure,
 } from "@nextui-org/react";
-import { TableActions } from "@/shared/components/ui/TableActions.tsx";
+import { EditDeleteActions } from "@shared/components/ui/EditDeleteActions.tsx";
 import { useDeleteCategory } from "@/modules/categories/hooks/useDeleteCategory.ts";
 import { useState } from "react";
 import { Category } from "@/modules/categories/interfaces/responses/category.interface.ts";
@@ -102,7 +102,7 @@ export function CategoriesTable() {
           {(category) => (
             <TableRow key={category.categoryId}>
               <TableCell>
-                <TableActions
+                <EditDeleteActions
                   deleteContent={"Delete category"}
                   editContent={"Edit category"}
                   onDelete={() => handleOnDelete(category.categoryId)}

--- a/src/modules/products/components/ProductsTable.tsx
+++ b/src/modules/products/components/ProductsTable.tsx
@@ -6,10 +6,10 @@ import {
   TableCell,
   TableColumn,
   TableHeader,
-  TableRow
+  TableRow,
 } from "@nextui-org/react";
 import { useGetProducts } from "@products/hooks/useGetProducts.ts";
-import { TableActions } from "@/shared/components/ui/TableActions.tsx";
+import { EditDeleteActions } from "@shared/components/ui/EditDeleteActions.tsx";
 import { useState } from "react";
 import { useDeleteProduct } from "@products/hooks/useDeleteProduct.ts";
 import { PaginationControls } from "@/shared/components/ui/PaginationControls.tsx";
@@ -102,7 +102,7 @@ export function ProductsTable() {
         {(product) => (
           <TableRow key={product.productId}>
             <TableCell>
-              <TableActions
+              <EditDeleteActions
                 confirmModalProps={{
                   title: "Delete product",
                   description: `Are you sure you want to delete the product ${product.name}?`,
@@ -133,7 +133,9 @@ export function ProductsTable() {
                 )}
               </span>
             </TableCell>
-            <TableCell>{currencyFormatter(product.price, "es-AR", "ARS")}</TableCell>
+            <TableCell>
+              {currencyFormatter(product.price, "es-AR", "ARS")}
+            </TableCell>
             <TableCell>
               <Chip
                 className="capitalize"

--- a/src/modules/sizes/components/DeletedSizesTable.tsx
+++ b/src/modules/sizes/components/DeletedSizesTable.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+
+import { AVAILABLE_TABLE_ACTIONS } from "@shared/interfaces/table-actions.interface.ts";
+import { PaginationControls } from "@shared/components/ui/PaginationControls.tsx";
+import { SizesTable } from "@sizes/components/SizesTable.tsx";
+import { useGetDeletedSizes } from "@sizes/hooks/useGetDeletedSizes.ts";
+import { useRestoreSize } from "@sizes/hooks/useRestoreSize.ts";
+
+export function DeletedSizesTable() {
+  const [currentPage, setCurrentPage] = useState(1);
+  const { restoreSize } = useRestoreSize();
+  const { sizes, isLoading } = useGetDeletedSizes({
+    page: currentPage,
+  });
+
+  function handlePageChange(page: number) {
+    setCurrentPage(page);
+  }
+
+  async function handleRestoreSize(sizeId: string) {
+    await restoreSize(sizeId);
+  }
+
+  return (
+    <SizesTable
+      bottomContent={
+        sizes &&
+        sizes.content.length > 0 && (
+          <PaginationControls
+            currentPage={currentPage}
+            handlePageChange={handlePageChange}
+            labelName={"sizes"}
+            paginatedResponse={sizes}
+          />
+        )
+      }
+      isLoading={isLoading}
+      sizes={sizes}
+      tableActionsProps={{
+        onRestore: handleRestoreSize,
+        type: AVAILABLE_TABLE_ACTIONS.RESTORE,
+      }}
+    />
+  );
+}

--- a/src/modules/sizes/components/SizesOverviewTable.tsx
+++ b/src/modules/sizes/components/SizesOverviewTable.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  useDisclosure,
+} from "@nextui-org/react";
+
+import { AVAILABLE_TABLE_ACTIONS } from "@shared/interfaces/table-actions.interface.ts";
+import { PaginationControls } from "@shared/components/ui/PaginationControls.tsx";
+import { Size } from "../interfaces/responses/size.interface";
+import { SizesTable } from "@sizes/components/SizesTable.tsx";
+import { UpdateSizeForm } from "./UpdateSizeForm";
+import { useDeleteSize } from "../hooks/useDeleteSize";
+import { useGetSizes } from "../hooks/useGetSizes";
+
+export function SizesOverviewTable() {
+  const [currentPage, setCurrentPage] = useState(1);
+  const { sizes, isLoading } = useGetSizes({
+    page: currentPage,
+  });
+  const { deleteSize } = useDeleteSize();
+  const { onOpen, onClose, isOpen } = useDisclosure();
+  const [updatingSize, setUpdatingSize] = useState<Size | undefined>(undefined);
+
+  function handleOnEdit(size: Size) {
+    setUpdatingSize(size);
+    onOpen();
+  }
+
+  function handlePageChange(page: number) {
+    setCurrentPage(page);
+  }
+
+  return (
+    <>
+      <SizesTable
+        tableActionsProps={{
+          onDelete: deleteSize,
+          onEdit: handleOnEdit,
+          type: AVAILABLE_TABLE_ACTIONS.EDIT_DELETE,
+        }}
+        sizes={sizes}
+        isLoading={isLoading}
+        bottomContent={
+          sizes &&
+          sizes.content.length > 0 && (
+            <PaginationControls
+              currentPage={currentPage}
+              handlePageChange={handlePageChange}
+              labelName={"sizes"}
+              paginatedResponse={sizes}
+            />
+          )
+        }
+      />
+
+      {updatingSize && (
+        <Modal isOpen={isOpen} onClose={onClose} backdrop={"blur"} size={"lg"}>
+          <ModalContent>
+            <ModalHeader>Edit size</ModalHeader>
+            <ModalBody>
+              <UpdateSizeForm size={updatingSize} onClose={onClose} />
+            </ModalBody>
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/modules/sizes/constants.ts
+++ b/src/modules/sizes/constants.ts
@@ -2,3 +2,5 @@ export const GET_SIZES_KEY = "sizes/get";
 export const DELETE_SIZE_KEY = "sizes/delete";
 export const CREATE_SIZE_KEY = "sizes/create";
 export const UPDATE_SIZE_KEY = "sizes/update";
+export const GET_DELETED_SIZES_KEY = "sizes/get-deleted";
+export const RESTORE_SIZE_KEY = "sizes/restore";

--- a/src/modules/sizes/hooks/useDeleteSize.ts
+++ b/src/modules/sizes/hooks/useDeleteSize.ts
@@ -1,5 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { DELETE_SIZE_KEY, GET_SIZES_KEY } from "@/modules/sizes/constants";
+import {
+  DELETE_SIZE_KEY,
+  GET_DELETED_SIZES_KEY,
+  GET_SIZES_KEY,
+} from "@/modules/sizes/constants";
 import { deleteSize } from "@/modules/sizes/sizes.service";
 
 export function useDeleteSize() {
@@ -8,9 +12,14 @@ export function useDeleteSize() {
     mutationFn: deleteSize,
     mutationKey: [DELETE_SIZE_KEY],
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: [GET_SIZES_KEY],
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [GET_SIZES_KEY],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [GET_DELETED_SIZES_KEY],
+        }),
+      ]);
     },
   });
 

--- a/src/modules/sizes/hooks/useGetDeletedSizes.ts
+++ b/src/modules/sizes/hooks/useGetDeletedSizes.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { GET_DELETED_SIZES_KEY } from "../constants";
+import { PaginationRequest } from "@/shared/interfaces/pagination/pagination-request.interface";
+import { getDeletedSizes } from "../sizes.service";
+
+export function useGetDeletedSizes(params: PaginationRequest) {
+  const { pageSize = 10, page = 0, ...rest } = params;
+  const fixedPage = page - 1 < 0 ? page : page - 1;
+
+  const { data, isLoading, isError } = useQuery({
+    queryFn: () =>
+      getDeletedSizes({
+        page: fixedPage,
+        pageSize,
+        ...rest,
+      }),
+    queryKey: [GET_DELETED_SIZES_KEY, fixedPage, pageSize],
+    staleTime: Infinity,
+  });
+
+  return { sizes: data, isLoading, isError };
+}

--- a/src/modules/sizes/hooks/useRestoreSize.ts
+++ b/src/modules/sizes/hooks/useRestoreSize.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  GET_DELETED_SIZES_KEY,
+  GET_SIZES_KEY,
+  RESTORE_SIZE_KEY,
+} from "@/modules/sizes/constants";
+import { restoreSize } from "@/modules/sizes/sizes.service";
+
+export function useRestoreSize() {
+  const queryClient = useQueryClient();
+  const { mutateAsync } = useMutation({
+    mutationFn: restoreSize,
+    mutationKey: [RESTORE_SIZE_KEY],
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [GET_SIZES_KEY],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [GET_DELETED_SIZES_KEY],
+        }),
+      ]);
+    },
+  });
+
+  return {
+    restoreSize: mutateAsync,
+  };
+}

--- a/src/modules/sizes/hooks/useSizesStore.ts
+++ b/src/modules/sizes/hooks/useSizesStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type Store = {
+  showDeleted: boolean;
+  setShowDeleted: (showDeleted: boolean) => void;
+};
+
+export const useSizesStore = create<Store>()(
+  persist(
+    (set) => ({
+      showDeleted: false,
+      setShowDeleted: (showDeleted: boolean) => {
+        set({ showDeleted });
+      },
+    }),
+    {
+      name: "sizes-storage",
+    },
+  ),
+);

--- a/src/modules/sizes/sizes.service.ts
+++ b/src/modules/sizes/sizes.service.ts
@@ -20,6 +20,20 @@ export async function getSizes(params: PaginationRequest) {
   return response.data;
 }
 
+export async function getDeletedSizes(params: PaginationRequest) {
+  const response = await httpClient.get<SizeResponse>(`${SIZES_URL}/deleted`, {
+    params,
+  });
+  return response.data;
+}
+
+export async function restoreSize(sizeId: string) {
+  const response = await httpClient.post<Size>(
+    `${SIZES_URL}/${sizeId}/restore`,
+  );
+  return response.data;
+}
+
 export async function updateSize(params: Size) {
   const response = await httpClient.put<Size>(`${SIZES_URL}/${params.sizeId}`, {
     ...params,

--- a/src/shared/components/icons/ClockIcon.tsx
+++ b/src/shared/components/icons/ClockIcon.tsx
@@ -1,0 +1,19 @@
+import { ComponentProps } from "react";
+
+type ClockIconProps = ComponentProps<"svg">;
+
+export function ClockIcon(props: ClockIconProps) {
+  return (
+    <svg
+      fill="green"
+      height="20px"
+      role={"presentation"}
+      viewBox="0 0 256 256"
+      width="20px"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M136,80v43.47l36.12,21.67a8,8,0,0,1-8.24,13.72l-40-24A8,8,0,0,1,120,128V80a8,8,0,0,1,16,0Zm88-24a8,8,0,0,0-8,8V82c-6.35-7.36-12.83-14.45-20.12-21.83a96,96,0,1,0-2,137.7,8,8,0,0,0-11-11.64A80,80,0,1,1,184.54,71.4C192.68,79.64,199.81,87.58,207,96H184a8,8,0,0,0,0,16h40a8,8,0,0,0,8-8V64A8,8,0,0,0,224,56Z"></path>
+    </svg>
+  );
+}

--- a/src/shared/components/ui/EditDeleteActions.tsx
+++ b/src/shared/components/ui/EditDeleteActions.tsx
@@ -1,12 +1,12 @@
 import { Tooltip } from "@nextui-org/react";
-import { DeleteIcon } from "@/shared/components/icons/DeleteIcon.tsx";
-import { EditIcon } from "@/shared/components/icons/EditIcon.tsx";
+import { DeleteIcon } from "@shared/components/icons/DeleteIcon.tsx";
+import { EditIcon } from "@shared/components/icons/EditIcon.tsx";
 import {
   ConfirmModalProps,
   useConfirmModal,
-} from "@/shared/hooks/useConfirmModal.ts";
+} from "@shared/hooks/useConfirmModal.ts";
 
-interface TableActionsProps {
+export interface EditDeleteActionsProps {
   deleteContent: string;
   editContent: string;
   onDelete?: () => Promise<void>;
@@ -16,7 +16,7 @@ interface TableActionsProps {
   allowDelete?: boolean;
 }
 
-export function TableActions(props: TableActionsProps) {
+export function EditDeleteActions(props: EditDeleteActionsProps) {
   const { deleteContent, editContent, onDelete, onEdit, confirmModalProps } =
     props;
   const { showConfirmModal } = useConfirmModal();
@@ -35,7 +35,7 @@ export function TableActions(props: TableActionsProps) {
   return (
     <div className="flex items-center gap-4">
       {allowEdit && (
-        <Tooltip content={editContent} delay={0} closeDelay={0}>
+        <Tooltip closeDelay={0} content={editContent} delay={0}>
           <button
             className="cursor-pointer text-lg text-default-400 active:opacity-50"
             onClick={onEdit}
@@ -47,10 +47,10 @@ export function TableActions(props: TableActionsProps) {
 
       {allowDelete && (
         <Tooltip
+          closeDelay={0}
           color="danger"
           content={deleteContent}
           delay={0}
-          closeDelay={0}
         >
           <button
             className="cursor-pointer text-lg text-danger active:opacity-50"

--- a/src/shared/components/ui/RestoreActions.tsx
+++ b/src/shared/components/ui/RestoreActions.tsx
@@ -1,0 +1,31 @@
+import { Tooltip } from "@nextui-org/react";
+
+import { ClockIcon } from "@shared/components/icons/ClockIcon.tsx";
+
+interface RestoreActionsProps {
+  onRestore: () => void;
+  toolTipContent?: string;
+}
+
+export function RestoreActions({
+  onRestore,
+  toolTipContent,
+}: RestoreActionsProps) {
+  return (
+    <div className={"flex items-center gap-4"}>
+      <Tooltip
+        closeDelay={0}
+        content={toolTipContent || "Restore"}
+        delay={0}
+        placement={"left"}
+      >
+        <button
+          className="cursor-pointer text-lg text-default-400 active:opacity-50"
+          onClick={onRestore}
+        >
+          <ClockIcon />
+        </button>
+      </Tooltip>
+    </div>
+  );
+}

--- a/src/shared/components/ui/ToggleDeletedButton.tsx
+++ b/src/shared/components/ui/ToggleDeletedButton.tsx
@@ -1,0 +1,29 @@
+import { Button } from "@nextui-org/react";
+
+import { EyeFilledIcon } from "@shared/components/icons/EyeFilledIcon.tsx";
+import { EyeSlashFilledIcon } from "@shared/components/icons/EyeSlashFilledIcon.tsx";
+
+interface ToggleDeletedButtonProps {
+  onClick: () => void;
+  showDeleted: boolean;
+}
+
+export function ToggleDeletedButton({
+  showDeleted,
+  onClick,
+}: ToggleDeletedButtonProps) {
+  return (
+    <Button
+      className={"w-full sm:w-auto"}
+      onClick={onClick}
+      variant={"bordered"}
+    >
+      {showDeleted ? (
+        <EyeSlashFilledIcon className="pointer-events-none text-2xl text-default-400" />
+      ) : (
+        <EyeFilledIcon className="pointer-events-none text-2xl text-default-400" />
+      )}
+      {showDeleted ? "Hide deleted" : "Show deleted"}
+    </Button>
+  );
+}

--- a/src/shared/interfaces/table-actions.interface.ts
+++ b/src/shared/interfaces/table-actions.interface.ts
@@ -1,0 +1,19 @@
+export enum AVAILABLE_TABLE_ACTIONS {
+  EDIT_DELETE = "EDIT_DELETE",
+  RESTORE = "RESTORE",
+}
+
+export type TableActions<T, Y> =
+  | EditDeleteActionsProps<T, Y>
+  | RestoreActionsProps<Y>;
+
+export type EditDeleteActionsProps<T, Y> = {
+  type: AVAILABLE_TABLE_ACTIONS.EDIT_DELETE;
+  onEdit: (item: T) => void;
+  onDelete: (id: Y) => Promise<void>;
+};
+
+export type RestoreActionsProps<T> = {
+  type: AVAILABLE_TABLE_ACTIONS.RESTORE;
+  onRestore: (id: T) => void;
+};

--- a/src/shared/pages/admin/sizes/SizesAdminPage.tsx
+++ b/src/shared/pages/admin/sizes/SizesAdminPage.tsx
@@ -1,27 +1,56 @@
 import { Button, Link } from "@nextui-org/react";
-import { PlusIcon } from "@/shared/components/icons/PlusIcon.tsx";
-import { Title } from "@/shared/components/typography/Title.tsx";
 import { Outlet } from "react-router-dom";
-import { SizesTable } from "@/modules/sizes/components/SizesTable.tsx";
+
+import RenderIf from "@shared/components/RenderIf.tsx";
+import { DeletedSizesTable } from "@sizes/components/DeletedSizesTable.tsx";
+import { PlusIcon } from "@shared/components/icons/PlusIcon.tsx";
+import { SizesOverviewTable } from "@sizes/components/SizesOverviewTable.tsx";
+import { Subtitle } from "@shared/components/typography/Subtitle.tsx";
+import { Title } from "@shared/components/typography/Title.tsx";
+import { ToggleDeletedButton } from "@shared/components/ui/ToggleDeletedButton.tsx";
+import { useSizesStore } from "@sizes/hooks/useSizesStore.ts";
 
 export function SizesAdminPage() {
+  const { showDeleted, setShowDeleted } = useSizesStore();
+
+  function handleShowDeleted() {
+    setShowDeleted(!showDeleted);
+  }
+
   return (
     <div className={"flex min-h-screenMinusNavbar flex-col gap-6 p-6"}>
       <header
         className={"flex w-full flex-wrap items-center justify-between gap-2"}
       >
         <Title>List of sizes</Title>
-        <Button
-          as={Link}
-          href={"/admin/sizes/create"}
-          color={"primary"}
-          className={"w-full sm:w-auto"}
-          startContent={<PlusIcon width={18} height={18} fill={"white"} />}
-        >
-          Create new
-        </Button>
+
+        <div className={"flex flex-wrap gap-2"}>
+          <ToggleDeletedButton
+            onClick={handleShowDeleted}
+            showDeleted={showDeleted}
+          />
+
+          <Button
+            as={Link}
+            href={"/admin/sizes/create"}
+            color={"primary"}
+            className={"w-full sm:w-auto"}
+            startContent={<PlusIcon width={18} height={18} fill={"white"} />}
+          >
+            Create new
+          </Button>
+        </div>
       </header>
-      <SizesTable />
+
+      <SizesOverviewTable />
+
+      <div className={"mt-2 flex flex-col gap-3"}>
+        <RenderIf condition={showDeleted}>
+          <Subtitle>List of deleted sizes</Subtitle>
+          <DeletedSizesTable />
+        </RenderIf>
+      </div>
+
       <Outlet />
     </div>
   );


### PR DESCRIPTION
Ahora mediante un botón se puede elegir si mostrar o no los tamaños eliminados.
Tuve que crear distintas tablas para realizar distintas abstracciones, antes teniamos una sola que mostraba los tamaños, pero ahora que necesitamos replicar la tabla con otra informacion y distintas acciones, es mejor separar en otros componentes.

PD: la selección de ver o no los eliminados persiste aunque reinicies, gracias al localStorage :+1: 

![ezgif-7-31135c1b62](https://github.com/user-attachments/assets/965b930d-67a0-47e3-920a-86e082e7cdec)
