### PR TITLE
test: create category equivalence

### DIFF
--- a/cypress/e2e/equivalence/create-category.cy.ts
+++ b/cypress/e2e/equivalence/create-category.cy.ts
@@ -1,0 +1,83 @@
+function visitCreateCategoryPage() {
+  cy.visit("/admin/categories/create");
+}
+
+function fillCategoryName(name: string) {
+  cy.dataCy("category-name").type(name);
+}
+
+function fillCategoryDescription(description: string) {
+  cy.dataCy("category-description").type(description);
+}
+
+function submitForm() {
+  cy.get("button[type=submit]").click();
+}
+
+describe("Create category", () => {
+  beforeEach(() => {
+    cy.login();
+    visitCreateCategoryPage();
+  });
+
+  it("should display an error if the category name is null", () => {
+    submitForm();
+    cy.dataCy("category-name").should("have.attr", "aria-invalid", "true");
+  });
+
+  it("should display an error message if the category name is one character less than the minimum length", () => {
+    fillCategoryName("aa");
+    submitForm();
+
+    cy.contains("Name must be at least 3 characters");
+  });
+
+  it("should create a new category if the category name is one character more than the minimum length", () => {
+    fillCategoryName("aaaa");
+    submitForm();
+
+    cy.url().should("include", "/admin/categories");
+  });
+
+  it("should create a new category if the category name is one character less than the maximum length", () => {
+    fillCategoryName("Ropa de Moda");
+    submitForm();
+
+    cy.url().should("include", "/admin/categories");
+  });
+
+  it("should show an error if the category name is one character more than the maximum length", () => {
+    fillCategoryName("Ropa de Moda Exclusiv");
+    submitForm();
+
+    cy.contains("Name must be less than 20 characters");
+  });
+
+  it("should create a new category if the category description is one character less than the maximum length", () => {
+    fillCategoryName("Ropa de Moda 2");
+    fillCategoryDescription("aa");
+    submitForm();
+
+    cy.url().should("include", "/admin/categories");
+  });
+
+  it("should create a new category if the category description is one character less than the maximum length", () => {
+    fillCategoryName("Ropa de Moda 3");
+    fillCategoryDescription(
+      "Prendas de vestir con diseño exclusivo, comodidad",
+    );
+    submitForm();
+
+    cy.url().should("include", "/admin/categories");
+  });
+
+  it("should show an error if the category description is one character more than the maximum length", () => {
+    fillCategoryName("Ropa de Moda 4");
+    fillCategoryDescription(
+      "Prendas de vestir con diseño exclusivo, comodidad e",
+    );
+    submitForm();
+
+    cy.contains("Description must be less than 50 characters");
+  });
+});

--- a/src/modules/categories/components/CreateCategoryForm.tsx
+++ b/src/modules/categories/components/CreateCategoryForm.tsx
@@ -28,6 +28,7 @@ export function CreateCategoryForm({ onClose }: CreateCategoryFormProps) {
         label={"Category name"}
         name={"name"}
         placeholder={"Type the category name"}
+        data-cy={"category-name"}
       />
 
       <InputField
@@ -35,6 +36,7 @@ export function CreateCategoryForm({ onClose }: CreateCategoryFormProps) {
         label={"Category description"}
         name={"description"}
         placeholder={"Type the category description"}
+        data-cy={"category-description"}
       />
 
       <CategoriesSelect

--- a/src/modules/categories/schemas/create-category.schema.ts
+++ b/src/modules/categories/schemas/create-category.schema.ts
@@ -5,6 +5,9 @@ export const CreateCategorySchema = z.object({
     .string({
       required_error: "",
     })
+    .min(3, {
+      message: "Name must be at least 3 characters",
+    })
     .max(20, {
       message: "Name must be less than 20 characters",
     }),


### PR DESCRIPTION
Se implementaron los tests definidos de partición de equivalencias definidos en el Notion para el _Registrar Categoría_.
Con esto sumamos +1 la cantidad de casos de prueba implementados.

**A tener en cuenta:**

Al implementar los tests de partición de equivalencias para el registro de categorías, es importante tener en cuenta que estos interactúan directamente con nuestro backend, creando registros en la base de datos cada vez que se ejecutan. Debido a que existen restricciones de nombres únicos, estos tests fallarán si ya existen registros previos con los mismos nombres.

Para evitar estos fallos, lo ideal sería ejecutar los tests en una base de datos sin registros previos. Actualmente se tendría que hacer a mano. Habría que buscar una solución para ello, además, para seguir con las buenas practicas de los tests: limpiar el estado.

**Ejecutar los tests**

Se puede hacer de manera interactiva, ejecutando: `pnpm cypress open`
O decirle que test queremos ejecutar: `pnpm cypress run --spec ./cypress/e2e/equivalence/create-category.cy.ts`