### PR TITLE
test: update category using equivalence partition

### DIFF
--- a/cypress/e2e/equivalence/categories/categories-utilities.cy.ts
+++ b/cypress/e2e/equivalence/categories/categories-utilities.cy.ts
@@ -1,0 +1,36 @@
+export function visitCreateCategoryPage() {
+  cy.visit("/admin/categories/create");
+}
+
+export function fillCategoryName(name: string) {
+  cy.dataCy("category-name").type(name);
+}
+
+export function fillCategoryDescription(description: string) {
+  cy.dataCy("category-description").type(description);
+}
+
+export function submitForm() {
+  cy.get("button[type=submit]").click();
+}
+
+export function visitCategoriesPage() {
+  cy.visit("/admin/categories");
+}
+
+export function clearAndType(selector: string, text: string) {
+  cy.dataCy(selector).clear();
+  cy.dataCy(selector).type(text);
+}
+
+export function clearAndTypeCategoryName(name: string) {
+  clearAndType("category-name", name);
+}
+
+export function clearAndTypeCategoryDescription(description: string) {
+  clearAndType("category-description", description);
+}
+
+export function assertCategoryUpdatedSuccessfully() {
+  cy.url().should("include", "/admin/categories");
+}

--- a/cypress/e2e/equivalence/categories/create-category.cy.ts
+++ b/cypress/e2e/equivalence/categories/create-category.cy.ts
@@ -1,18 +1,9 @@
-function visitCreateCategoryPage() {
-  cy.visit("/admin/categories/create");
-}
-
-function fillCategoryName(name: string) {
-  cy.dataCy("category-name").type(name);
-}
-
-function fillCategoryDescription(description: string) {
-  cy.dataCy("category-description").type(description);
-}
-
-function submitForm() {
-  cy.get("button[type=submit]").click();
-}
+import {
+  fillCategoryDescription,
+  fillCategoryName,
+  submitForm,
+  visitCreateCategoryPage,
+} from "./categories-utilities.cy";
 
 describe("Create category", () => {
   beforeEach(() => {

--- a/cypress/e2e/equivalence/categories/update-category.cy.ts
+++ b/cypress/e2e/equivalence/categories/update-category.cy.ts
@@ -1,0 +1,53 @@
+import {
+  assertCategoryUpdatedSuccessfully,
+  clearAndTypeCategoryDescription,
+  clearAndTypeCategoryName,
+  submitForm,
+  visitCategoriesPage,
+} from "./categories-utilities.cy";
+
+describe("Update category", () => {
+  beforeEach(() => {
+    cy.login();
+    visitCategoriesPage();
+    cy.dataCy("table-edit-button").first().click();
+  });
+
+  it("should show an error if the category name is less than three characters", () => {
+    clearAndTypeCategoryName("a");
+    submitForm();
+    cy.contains("Name must be at least 3 characters");
+  });
+
+  it("should update the category if the name is more or equal than three characters", () => {
+    clearAndTypeCategoryName("aaaa");
+    submitForm();
+    assertCategoryUpdatedSuccessfully();
+  });
+
+  it("should update the category if the name is less or equal than twenty characters", () => {
+    clearAndTypeCategoryName("aaaaaaa");
+    submitForm();
+    assertCategoryUpdatedSuccessfully();
+  });
+
+  it("should show an error if the category name is more than twenty characters", () => {
+    clearAndTypeCategoryName("aaaaaaaaaaaaaaaaaaaaaaaa");
+    submitForm();
+    cy.contains("Name must be less than 20 characters");
+  });
+
+  it("should update the category if the name is less or equal than fifty characters", () => {
+    clearAndTypeCategoryDescription("aaaaaaaaaaaaaaaaaaaaaaaa");
+    submitForm();
+    assertCategoryUpdatedSuccessfully();
+  });
+
+  it("should show an error if the category name is more than fifty characters", () => {
+    clearAndTypeCategoryDescription(
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    submitForm();
+    cy.contains("Description must be less than 50 characters");
+  });
+});

--- a/src/modules/categories/components/EditCategoryForm.tsx
+++ b/src/modules/categories/components/EditCategoryForm.tsx
@@ -74,6 +74,7 @@ export function EditCategoryForm({ onClose, category }: EditCategoryFormProps) {
         label={"Category name"}
         name={"name"}
         placeholder={"Type the category name"}
+        data-cy={"category-name"}
       />
 
       <InputField
@@ -81,6 +82,7 @@ export function EditCategoryForm({ onClose, category }: EditCategoryFormProps) {
         label={"Category description"}
         name={"description"}
         placeholder={"Type the category description"}
+        data-cy={"category-description"}
       />
 
       <ControlledSelect

--- a/src/modules/categories/schemas/update-category.schema.ts
+++ b/src/modules/categories/schemas/update-category.schema.ts
@@ -5,8 +5,8 @@ export const UpdateCategorySchema = z.object({
     .string({
       required_error: "",
     })
-    .min(1, {
-      message: "Name is required",
+    .min(3, {
+      message: "Name must be at least 3 characters",
     })
     .max(20, {
       message: "Name must be less than 20 characters",

--- a/src/shared/components/ui/EditDeleteActions.tsx
+++ b/src/shared/components/ui/EditDeleteActions.tsx
@@ -39,6 +39,7 @@ export function EditDeleteActions(props: EditDeleteActionsProps) {
           <button
             className="cursor-pointer text-lg text-default-400 active:opacity-50"
             onClick={onEdit}
+            data-cy={"table-edit-button"}
           >
             <EditIcon />
           </button>


### PR DESCRIPTION
Implementación de otro caso de prueba más, correspondiente al _actualizar categoría_ de la partición de equivalencias. Con esto **nos restan ocho casos de prueba a implementar.**

Algunas acciones extras:

- Se agregaron atributos para identificar a los _inputs_ en los tests, y
- Se creó un archivo con las utilidades usadas en los tests de categorías, como para evitar duplicar un poco. De hecho, hay algunas funciones que pueden ser mas generales, pero quiero evitar esta abstracción porque quizás ni se requiera.